### PR TITLE
[FEAT] Vector DB에 금융 데이터 저장

### DIFF
--- a/findata_api/vectorDB.py
+++ b/findata_api/vectorDB.py
@@ -1,0 +1,38 @@
+from typing import Dict, List
+from FlagEmbedding import BGEM3FlagModel
+from qdrant_client import QdrantClient
+from qdrant_client.models import PointStruct, VectorParams, Distance
+from tqdm import tqdm
+import uuid
+
+
+def get_qdrant_local(
+    collection_name: str = "finance_products",
+    category: str = "deposit",
+    vector_size: int = 1024,
+    path: str = "./qdrant_localdb",
+) -> QdrantClient:
+    """
+    Qdrant VectorDB 불러오는 함수
+    - 로컬 경로에 Qdrant localdb 사용
+    - collection이 이미 있으면 그대로 사용
+    - 없으면 create_collection 수행
+
+    arguments:
+        (str) collection_name: 금융데이터 DB 이름
+        (str) category: 세부 카테고리
+        (int) vector_size: embedding vector size
+        (str) path: VectorDB 저장 경로
+    return:
+        QdrantClient: Qdrant VectorDB Client
+    """
+    collection_name = collection_name + "_" + category
+    client = QdrantClient(path=path)
+
+    if not client.collection_exists(collection_name):
+        client.create_collection(
+            collection_name=collection_name,
+            vectors_config=VectorParams(size=vector_size, distance=Distance.COSINE),
+        )
+    # 존재하면 아무 것도 하지 않고 그대로 반환
+    return client

--- a/findata_api/vectorDB.py
+++ b/findata_api/vectorDB.py
@@ -36,3 +36,46 @@ def get_qdrant_local(
         )
     # 존재하면 아무 것도 하지 않고 그대로 반환
     return client
+
+
+def save_vectorDB(
+    chunked_docs: List[str],
+    collection_name: str = "finance_products",
+    category: str = "deposit",
+    vector_size: int = 1024,
+    path: str = "./qdrant_localdb",
+) -> QdrantClient:
+    """
+    VectorDB에 Chunked data 저장하는 함수
+    - "BAAI/bge-m3" Embedding Model 사용
+    - Qdrant VectorDB 사용
+
+    arguments:
+        (List[str]) chunked_docs: Chunking된 금융데이터 리스트
+        (str) collection_name: 금융데이터 DB 이름
+        (str) category: 세부 카테고리
+        (int) vector_size: embedding vector size
+        (str) path: VectorDB 저장 경로
+    return:
+        QdrantClient: Qdrant VectorDB Client
+    """
+
+    # bge-m3 임베딩 모델 로드
+    model = BGEM3FlagModel("BAAI/bge-m3", use_fp16=False)
+    collection_name = collection_name + "_" + category
+    # Qdrant 초기화
+    client = get_qdrant_local(
+        collection_name=collection_name,
+        vector_size=1024,
+    )
+
+    points = []
+    for i, doc in enumerate(tqdm(chunked_docs, desc="임베딩 + 업로드 중")):
+        vec = model.encode([doc.page_content], return_dense=True)["dense_vecs"][0]
+        point_id = str(uuid.uuid4())
+        payload = {**doc.metadata, "chunk_id": i, "text": doc.page_content}
+        points.append(PointStruct(id=point_id, vector=vec, payload=payload))
+
+    client.upsert(collection_name=collection_name, points=points)
+    print(f"\n 업로드 완료: 총 {len(points)}개 chunk (Document 기반)")
+    return client

--- a/findata_api/vectorDB.py
+++ b/findata_api/vectorDB.py
@@ -1,9 +1,10 @@
+import uuid
 from typing import Dict, List
+
 from FlagEmbedding import BGEM3FlagModel
 from qdrant_client import QdrantClient
-from qdrant_client.models import PointStruct, VectorParams, Distance
+from qdrant_client.models import Distance, PointStruct, VectorParams
 from tqdm import tqdm
-import uuid
 
 
 def get_qdrant_local(


### PR DESCRIPTION
### [FEAT] Vector DB에 금융 데이터 저장

### 작업 개요
간편하게 쓸 수 있는 embedding model과 vectorDB를 사용해서 금융데이터를 vectorDB에 적재

### 변경 사항
- chunk된 자연어를 embedding model로 embedding변환하는 함수 작성
- vectorDB에 적재하는 함수 작성

### 확인 요청
- [ ] 코드 스타일(black, isort 등) 검사 통과  
- [ ] 리뷰어가 이해할 수 있도록 주석 및 설명 추가  

### 참고 사항
- 관련 이슈: #62 
