### PR TITLE
[UI] 채팅 페이지 레이아웃 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,5 +280,8 @@ pip-selfcheck.json
 # ------------------------
 # VSCODE / LOCAL SETTINGS
 # ------------------------
+
+# 미래 충돌 방지를 위해 추가
+.vscode/
 # Live Server 활용하며 자동 생성된 파일
 .vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -276,3 +276,9 @@ pyvenv.cfg
 pip-selfcheck.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python,django,venv
+
+# ------------------------
+# VSCODE / LOCAL SETTINGS
+# ------------------------
+# Live Server 활용하며 자동 생성된 파일
+.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "liveServer.settings.port": 5501
-}

--- a/temp_ui/chat.html
+++ b/temp_ui/chat.html
@@ -1,0 +1,65 @@
+<!-- AI CHAT 화면 -->
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Finbot</title>
+
+    <link rel="stylesheet" href="css/chat.css">
+
+    <!-- 구글 폰트 불러오기 -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR&display=swap" rel="stylesheet">
+</head>
+
+<body>
+    <div id="sidebar" class="sidebar">
+        <!-- 1. 토글 버튼 -->
+        <div class="toggle-btn" onclick="toggleSidebar()">
+            <span class="toggle-icon">&#x2630;</span> 
+        </div>
+
+        <!-- 1-1. 최근 대화 목록 -->
+        <p class="recent-title">최근 대화 목록</p>
+
+        <!-- 1-2. 대화 저장 내역 리스트 -->
+        <ul class="chat-list">
+        </ul>
+    </div>
+
+    <div class="chat-main">
+        <!-- 2. 메시지 출력 영역 -->
+        <div class="messages-area">
+            
+            <!-- 초기 화면 환영 메시지 -->
+            <div class="message-container bot-message">
+                <div class="bubble">
+                    안녕하세요. 무엇을 도와드릴까요?
+                </div>
+            </div>
+        </div>
+
+        <!-- 3. 대화 입력 영역 -->
+        <form class="input-area">
+
+            <!-- 3-1. 대화 입력 창 -->
+            <textarea id="chat-input" name="message" placeholder="메시지를 입력해 주세요"></textarea>
+            
+            <!-- 3-2. 대화 전송 버튼 -->
+            <button id="send-btn" type="submit">
+                <span style="font-size: 20px; transform: translateX(2px);">▶</span> 
+            </button>
+        </form>
+    </div>
+
+    <!-- 사이드바 토글 로직 (JavaScript) -->
+    <script>
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+        }
+    </script>
+</body>
+</html>

--- a/temp_ui/chat.html
+++ b/temp_ui/chat.html
@@ -49,7 +49,7 @@
             
             <!-- 3-2. 대화 전송 버튼 -->
             <button id="send-btn" type="submit">
-                <span style="font-size: 20px; transform: translateX(2px);">▶</span> 
+                <span style="font-size: 15px; transform: translateX(2px);">▶</span> 
             </button>
         </form>
     </div>

--- a/temp_ui/css/chat.css
+++ b/temp_ui/css/chat.css
@@ -214,14 +214,13 @@
 
     /* 전송 버튼 */
     #send-btn {
-        height: 40px; 
-        width: 40px; 
+        height: 30px; 
+        width: 35px; 
         background-color: transparent; 
         color: #8B8B8B; 
         border: none;
         border-radius: 0; 
         cursor: pointer;
-        font-size: 24px; 
         display: flex;
         align-items: center;
         justify-content: center;

--- a/temp_ui/css/chat.css
+++ b/temp_ui/css/chat.css
@@ -1,0 +1,241 @@
+    body {
+        margin: 0;
+        padding: 20px;
+        background-color: #FFFFFF;
+        font-family: 'Noto Sans KR', sans-serif;
+        height: 100vh;
+        display: flex;
+        overflow: hidden;
+        font-size: 15px;
+        box-sizing: border-box;
+    }
+    
+    /* ---------- */
+    /* 1. 사이드바 */
+    /* ---------- */
+    .sidebar {
+        width: 85px;
+        height: 100%;
+        background-color: #F3F3F3;
+        color: #8B8B8B; 
+        padding: 20px 0;
+        box-sizing: border-box;
+        transition: width 0.3s ease;
+        display: flex;
+        flex-direction: column;
+        border-radius: 15px;
+        flex-shrink: 0; 
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+        position: relative;
+    }
+    
+    .sidebar.open {
+        width: 300px; 
+        padding-left: 20px;
+    }
+
+    /* 토글 버튼 */
+    .toggle-btn {
+        position: absolute; 
+        top: 20px;
+        left: 0;
+        
+        width: 40px; 
+        height: 40px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        
+        /* 닫혔을 때 중앙 정렬 위치로 고정 */
+        transform: translateX(22.5px); 
+        transition: color 0.2s, background-color 0.2s;
+        
+        cursor: pointer;
+        color: #8B8B8B; 
+        font-size: 24px; 
+        border-radius: 5px;
+        z-index: 10;
+    }
+
+    /* 토글이 열려도 버튼 위치 고정 */
+    .sidebar.open .toggle-btn {
+        transform: translateX(22.5px);
+    }
+
+
+    .toggle-btn:hover {
+        color: #3F72AF;
+        background-color: #E5E5E5;
+    }
+    
+    /* 토글 아이콘 */
+    .toggle-icon {
+        display: inline-block;
+        font-size: 24px;
+        line-height: 1;
+    }
+
+
+    /* 대화 내역 저장 */
+    .recent-title {
+        font-size: 15px;
+        font-weight: bold;
+        margin: 70px 0 15px 20px; 
+        color: #8B8B8B; 
+        padding: 0;
+        white-space: nowrap; 
+        opacity: 0; 
+        transition: opacity 0.3s ease;
+    }
+
+    .sidebar.open .recent-title {
+        opacity: 1;
+    }
+
+    /* 저장된 채팅 목록 */
+    .chat-list {
+        padding: 0 20px 0 20px;
+        list-style: none;
+        overflow-y: auto;
+        opacity: 0;
+        transition: opacity 0.3s ease;
+    }
+    
+    .sidebar.open .chat-list {
+        opacity: 1;
+    }
+
+    .chat-list li {
+        padding: 10px 10px;
+        margin-bottom: 5px;
+        border-radius: 10px;
+        cursor: pointer;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        transition: background-color 0.2s;
+    }
+
+    .chat-list li:hover {
+        background-color: #E5E5E5;
+    }
+
+    /* 닫힌 상태에서 채팅 리스트 숨기기 */
+    .sidebar:not(.open) .recent-title,
+    .sidebar:not(.open) .chat-list {
+        position: absolute; 
+        visibility: hidden;
+    }
+    
+    /* --------------- */
+    /* 2. 메인 채팅 영역 */
+    /* --------------- */
+    .chat-main {
+        flex-grow: 1;
+        height: 100%; 
+        display: flex;
+        flex-direction: column;
+        background-color: #FFFFFF;
+        margin-left: 10px; 
+        border-radius: 20px; 
+    }
+
+    /* 채팅 메시지 출력 영역 */
+    .messages-area {
+        flex-grow: 1;
+        /* 입력 영역의 padding과 동일하여야 함 */
+        padding: 20px 20px;
+        overflow-y: auto; 
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-end; 
+    }
+
+    /* 개별 메시지 컨테이너 */
+    .message-container {
+        display: flex;
+        margin-bottom: 15px; 
+    }
+
+    /* 말풍선 공통 스타일 */
+    .bubble {
+        max-width: 60%; 
+        padding: 15px 15px; 
+        border-radius: 20px; 
+        line-height: 1.5;
+        display: flex;
+        align-items: center; 
+    }
+
+    /* 상대방 말풍선 */
+    .bot-message .bubble {
+        background-color: #F3F3F3; 
+        color: #000000; 
+        border-bottom-left-radius: 0; 
+    }
+
+    /* 사용자 말풍선 */
+    .user-message .bubble {
+        background-color: #3F72AF; 
+        color: #FFFFFF; 
+        border-bottom-right-radius: 0; 
+    }
+    
+    /* ----------- */
+    /* 3. 입력 영역 */
+    /* ----------- */
+    .input-area {
+        display: flex;
+        align-items: center;
+        padding: 20px 40px 5px 20px; 
+        flex-shrink: 0;
+        position: relative; 
+    }
+
+    /* 대화 입력 창 */
+    #chat-input {
+        flex-grow: 1;
+        height: 100px; 
+        border: 1px solid #E5E5E5; 
+        background-color: #FFFFFF; 
+        border-radius: 20px;
+        padding: 15px 70px 15px 20px; 
+        font-size: 15px;
+        resize: none; 
+        box-sizing: border-box;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+        font-family: 'Noto Sans KR', sans-serif;
+    }
+
+    /* 호버 시 색상 변경 없음 */
+    #chat-input:focus {
+        outline: none;
+    }
+
+    /* 전송 버튼 */
+    #send-btn {
+        height: 40px; 
+        width: 40px; 
+        background-color: transparent; 
+        color: #8B8B8B; 
+        border: none;
+        border-radius: 0; 
+        cursor: pointer;
+        font-size: 24px; 
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        transition: color 0.2s; 
+        
+        /* 버튼 위치 */
+        position: absolute;
+        right: 50px; 
+        bottom: 20px; 
+    }
+
+    /* 호버 시 검은색으로 색상 변경 */
+    #send-btn:hover {
+        background-color: transparent;
+        color: #000000; 
+    }


### PR DESCRIPTION
### 작업 개요
채팅 페이지 레이아웃 구성

### 변경 사항
- AI 채팅 페이지 구성을 위한 chat.html과 chat.css 생성
- 현재는 새로고침을 하여도 메세지 전송 불가능
- 사이드바 토글에 JavaScript 로직 일부 활용

### 확인 요청
- [x] 왼쪽 상단 토글 클릭 시 사이드바 오픈 여부 확인
- [x] Live Server와 Figma 화면의 유사도 확인
- [x] 주석의 명확성 및 이해 용이성 확인
- [x] 오탈자 확인

### 참고 사항
- 관련 이슈: #81
- 테스트 방법: VSCODE EXTENSIONS 'Live Server' 설치 후 'Open with Live Server' 실행
- 참고 링크: [Figma](https://www.figma.com/design/d5wUdEqpVASTVH6Ww1aiir/AI-Agent?node-id=0-1&t=nXHQmaa0hHVisrDJ-1)
