### PR TITLE
[Fix] models.py LIFE_AREA_CHOICES 오타 수정

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -32,7 +32,7 @@ class User(AbstractUser):
         ("1억원 이상", "1억원 이상"),
     ]
 
-    LIFE_AREA_CHICES = [
+    LIFE_AREA_CHOICES = [
         ("서울특별시", "서울특별시"),
         ("부산광역시", "부산광역시"),
         ("인천광역시", "인천광역시"),
@@ -66,5 +66,5 @@ class User(AbstractUser):
         max_length=20, null=True, choices=EARNINGS_CHOICES, verbose_name="소득"
     )
     life_area = models.CharField(
-        max_length=20, null=True, choices=LIFE_AREA_CHICES, verbose_name="거주지역"
+        max_length=20, null=True, choices=LIFE_AREA_CHOICES, verbose_name="거주지역"
     )


### PR DESCRIPTION
### 작업 개요
accounts/models.py 내 LIFE_AREA_CHICES 오타를 LIFE_AREA_CHOICES로 수정

### 변경 사항
- accounts/models.py
  - LIFE_AREA_CHICES → LIFE_AREA_CHOICES 오타 수정
  - User 모델 내 life_area 필드 choices 참조 부분 업데이트

### 확인 요청(#77 과 동일)
- [x] 로그인 후 회원 정보 페이지로 이동
- [x]  회원 정보 페이지로 이동할 때 비밀번호를 요청하는지 확인
- [x]  비밀번호를 틀렸을 경우 비밀번호가 잘못되었다는 에러 메시지와 함께 다시 비밀번호를 입력하도록 하는지 확인
- [x]  회원 정보 수정 페이지에서 회원 탈퇴 버튼을 클릭했을 때 다시 비밀번호 인증을 요청하는지 확인
- [x]  회원 정보 수정 후 저장 시 DB에 반영되는지 확인
- [x]  회원 정보 수정 후 저장 -> 다시 회원 정보 수정 페이지에 접속하면 수정한 정보가 반영되어 출력되는지 확인

### 참고 사항
- 관련 이슈
#125
#77
 
 ---

- 테스트 방법

1. 가상환경 생성, 활성화

```
python -m venv venv
source venv/Scripts/activate
```

2. 패키지 설치

```
pip install -r requirements.txt
```

3. .env 작성

4. 서버 실행(서버 실행 이후 회원가입 url 부터 해야 함)
```
python manage.py runserver
```
<img width="1096" height="698" alt="image" src="https://github.com/user-attachments/assets/b3a5e507-5da3-4a8f-a8ee-bfb9a9f2c6ab" />