### PR TITLE
[Fix] chatbot app에 app_name 정의 추가

### DIFF
--- a/chatbot/urls.py
+++ b/chatbot/urls.py
@@ -2,6 +2,9 @@ from django.urls import path
 
 from . import views
 
+
+app_name = "chat"
+
 urlpatterns = [
     path("", views.chat_page, name="chat_page"),  # 대화 페이지
 ]

--- a/chatbot/urls.py
+++ b/chatbot/urls.py
@@ -2,7 +2,6 @@ from django.urls import path
 
 from . import views
 
-
 app_name = "chat"
 
 urlpatterns = [

--- a/chatbot/views.py
+++ b/chatbot/views.py
@@ -37,7 +37,7 @@ def chat_page(request):
             ChatMessage.objects.create(role="bot", message=reply)
 
         # POST 후 새로고침 시 중복 전송 방지를 위해 리다이렉트
-        return redirect("chat_page")
+        return redirect("chat:chat_page")
 
     # GET 요청일 경우 (화면 처음 열었을 때 or 새로고침)
     messages = ChatMessage.objects.all().order_by("created_at")  # 오래된 순

--- a/finbot/urls.py
+++ b/finbot/urls.py
@@ -22,5 +22,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("accounts/", include("accounts.urls")),
     path("products/", include("products.urls")),
-    path("chat/", include("chatbot.urls")), 
+    path("chat/", include("chatbot.urls")),
 ]

--- a/finbot/urls.py
+++ b/finbot/urls.py
@@ -22,5 +22,5 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("accounts/", include("accounts.urls")),
     path("products/", include("products.urls")),
-    path("chat/", include("chatbot.urls")),
+    path("chat/", include("chatbot.urls")), 
 ]


### PR DESCRIPTION
### 작업 개요
chatbot 앱의 URL 설정 파일(chatbot/urls.py)에 app_name이 누락을 수정했습니다.

### 변경 사항
- chatbot/urls.py 상단에 app_name = "chat" 추가

### 확인 요청
- [x] 코드 스타일(black, isort 등) 검사 통과  
- [x] python manage.py runserver 실행 후 /chat/ 페이지 정상 출력 확인

### 참고 사항
관련 이슈
#135 
테스트 방법:
1. 서버 실행 → python manage.py runserver
2. 브라우저에서 http://127.0.0.1:8000/chat/ 접속
3. 정상 페이지 렌더링 및 URL 에러 미발생 확인
