### PR TITLE
[REFACTOR] 금융데이터 API 호출 추상화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,6 @@
 SECRET_KEY="DJANGO_SECRET_KEY_GOES_HERE"
 # 금융감독원 금융상품한눈에 open api key
 FINAPI_KEY="FiNANCE_DATA_OPEN_API_KEY"
-# 정기예금 api 호출 주소
-FIXED_DEPOSIT_URL="http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?" 
 # openai api key
 OPENAI_API_KEY="OPENAI_API_KEY"
 

--- a/findata/call_findata_api.py
+++ b/findata/call_findata_api.py
@@ -6,6 +6,9 @@ from typing import Dict, List
 
 import requests
 from dotenv import load_dotenv
+from findata.config_manager import JsonConfigManager
+
+import argparse
 
 """
 <금융상품한눈에 api 데이터 처리 가이드>
@@ -19,61 +22,34 @@ from dotenv import load_dotenv
 # .env 파일을 읽어 환경 변수로 설정
 BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")  # 프로젝트 폴더의 .env.example에 환경변수 입력
+conf_path = BASE_DIR / "findata/config.json"
+# config load
+conf = JsonConfigManager(path = conf_path).values
 
 # dotenv를 활용하여 API 키 가져오기
 FINAPI_KEY = os.getenv("FINAPI_KEY")
-# 공식 문서를 참고하여 API 검색 URL 설정하기
-FIXED_DEPOSIT_URL = os.getenv("FIXED_DEPOSIT_URL")
-
-# API 호출에 필요한 파라미터(필수)
-# 금융기관별 코드 list: 데이터 명세 참고
-fin_grp_dict = {
-    "020000": "은행",  # 은행
-    "030200": "여신전문",  # 여신전문
-    "030300": "저축은행",  # 저축은행
-    "050000": "보험회사",  # 보험회사
-    "060000": "금융투자",  # 금융투자
-}
-
-# 수집할 상품 스펙의 태그명 list: 데이터 명세 참고
-item_dict = {
-    "kor_co_nm": "금융회사명",  # 금융회사명
-    "fin_co_no": "금융회사코드",  # 금융회사코드
-    "fin_prdt_nm": "금융상품명",  # 금융상품명
-    "fin_prdt_cd": "금융상품코드",  # 금융상품코드
-    "join_way": "가입방법",  # 가입방법
-    "mtrt_int": "만기후이자율",  # 만기후이자율
-    "spcl_cnd": "우대조건",  # 우대조건
-    "join_deny": "가입제한",  # 가입제한 1:제한X, 2:서민전용, 3:일부제한
-    "join_member": "가입대상",  # 가입대상
-    "max_limit": "최고한도",  # 최고한도
-    "intr_rate_type": "적립유형명",  # 적립유형명
-    "intr_rate_type_nm": "저축금리유형명",  # 저축금리유형명
-    "save_trm": "저축개월",  # 저축개월 [단위: 개월]
-    "intr_rate": "저축금리",  # 저축금리 [소수점 2자리]
-    "intr_rate2": "최고우대금리",  # 최고우대금리
-    "dcls_strt_day": "공시시작일",  # 공시시작일
-    "dcls_end_day": "공시종료일",  # 공시종료일
-    "dcls_month": "공시제출월",  # 공시제출월
-}
-
 
 # 금융 데이터를 가져오는 함수 정의
-def fetch_findata() -> List[Dict]:
+def fetch_findata(category = "fixed_deposit") -> List[Dict]:
     """
-    일단은 예금만 가져오게 설정. 적금, 연금저축, 주택담보대출, 전세자금대출, 개인신용대출을 불러오려면 develop 필요.
+    정기예금, 적금, 전세자금대출 호출 가능하도록 develop한 version
     # 데이터베이스에 저장
     return : List[Dict(상품)], 데이터 리스트 반환
     """
-
+    # category 유효성
+    assert category in ["fixed_deposit", "installment_deposit", "jeonse_loan"]
     # 현재 날짜 저장
     today = date.today()
     format_today = today.strftime("%Y%m%d")
     today_date = datetime(
         int(format_today[:4]), int(format_today[4:6]), int(format_today[6:8])
     )
-    # URL 저장
-    url = FIXED_DEPOSIT_URL
+
+    # API 호출에 필요한 파라미터(필수)
+    url = conf.urls[category]
+    fin_grp_dict = conf.fin_co_no
+    item_dict = conf.tags[category]
+
     # 최종 데이터 저장 할 data
     data = []
     # 금융기관별 api info 가져오기
@@ -97,9 +73,11 @@ def fetch_findata() -> List[Dict]:
         code_dict[group]["total_count"] = ex_data["result"]["total_count"]
         code_dict[group]["max_page_no"] = ex_data["result"]["max_page_no"]
 
-    # 모든 데이터 조회 및 정리
-    # [ requests 문서를 참고하여 응답 데이터를  python의 dict 타입으로 변환하여 data 변수에 저장 ]
+    # 모든 데이터 조회 및 정리"fixed_deposit", "installment_deposit", "jeonse_loan"
+    fin_cat = {"fixed_deposit":"정기예금", "installment_deposit":"적금", "jeonse_loan":"전세자금대출"}
+    
     print("금융상품 통합비교공시 '금융상품한눈에' 오픈 API 호출을 시작합니다.")
+    print(f"Current Finance Category : {fin_cat[category]}")
     for group in fin_grp_dict.keys():
         group_name = fin_grp_dict[group]
         count = code_dict[group]["total_count"]
@@ -171,4 +149,8 @@ def fetch_findata() -> List[Dict]:
 
 
 if __name__ == "__main__":
-    fetch_findata()
+    parser = argparse.ArgumentParser(description='This is calling finance data program from api')
+    # ["fixed_deposit", "installment_deposit", "jeonse_loan"] 중 하나
+    parser.add_argument('--category', '-c', type=str, default="fixed_deposit", help='category of finance data')
+    args = parser.parse_args()
+    fetch_findata(category=args.category)

--- a/findata/call_findata_api.py
+++ b/findata/call_findata_api.py
@@ -1,3 +1,4 @@
+import argparse
 import os  # 운영 체제와 상호작용하기 위한 라이브러리
 from datetime import date, datetime
 from pathlib import Path  # 파일 경로 처리를 위한 라이브러리
@@ -6,9 +7,8 @@ from typing import Dict, List
 
 import requests
 from dotenv import load_dotenv
-from findata.config_manager import JsonConfigManager
 
-import argparse
+from findata.config_manager import JsonConfigManager
 
 """
 <금융상품한눈에 api 데이터 처리 가이드>
@@ -24,13 +24,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 load_dotenv(BASE_DIR / ".env")  # 프로젝트 폴더의 .env.example에 환경변수 입력
 conf_path = BASE_DIR / "findata/config.json"
 # config load
-conf = JsonConfigManager(path = conf_path).values
+conf = JsonConfigManager(path=conf_path).values
 
 # dotenv를 활용하여 API 키 가져오기
 FINAPI_KEY = os.getenv("FINAPI_KEY")
 
+
 # 금융 데이터를 가져오는 함수 정의
-def fetch_findata(category = "fixed_deposit") -> List[Dict]:
+def fetch_findata(category="fixed_deposit") -> List[Dict]:
     """
     정기예금, 적금, 전세자금대출 호출 가능하도록 develop한 version
     # 데이터베이스에 저장
@@ -74,8 +75,12 @@ def fetch_findata(category = "fixed_deposit") -> List[Dict]:
         code_dict[group]["max_page_no"] = ex_data["result"]["max_page_no"]
 
     # 모든 데이터 조회 및 정리"fixed_deposit", "installment_deposit", "jeonse_loan"
-    fin_cat = {"fixed_deposit":"정기예금", "installment_deposit":"적금", "jeonse_loan":"전세자금대출"}
-    
+    fin_cat = {
+        "fixed_deposit": "정기예금",
+        "installment_deposit": "적금",
+        "jeonse_loan": "전세자금대출",
+    }
+
     print("금융상품 통합비교공시 '금융상품한눈에' 오픈 API 호출을 시작합니다.")
     print(f"Current Finance Category : {fin_cat[category]}")
     for group in fin_grp_dict.keys():
@@ -149,8 +154,16 @@ def fetch_findata(category = "fixed_deposit") -> List[Dict]:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='This is calling finance data program from api')
+    parser = argparse.ArgumentParser(
+        description="This is calling finance data program from api"
+    )
     # ["fixed_deposit", "installment_deposit", "jeonse_loan"] 중 하나
-    parser.add_argument('--category', '-c', type=str, default="fixed_deposit", help='category of finance data')
+    parser.add_argument(
+        "--category",
+        "-c",
+        type=str,
+        default="fixed_deposit",
+        help="category of finance data",
+    )
     args = parser.parse_args()
     fetch_findata(category=args.category)

--- a/findata/config.json
+++ b/findata/config.json
@@ -1,8 +1,13 @@
 {
+	"category": {
+		"정기예금": "fixed_deposit",
+		"적금": "installment_deposit",
+		"전세대출": "jeonse_loan"
+	},
 	"urls": {
-		"FIXED_DEPOSIT_URL": "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
-		"INSTALLMENT_DEPOSIT_URL": "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
-		"JEONSE_LOAN_URL": "http://finlife.fss.or.kr/finlifeapi/rentHouseLoanProductsSearch.json?"
+		"fixed_deposit": "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
+		"installment_deposit": "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
+		"jeonse_loan": "http://finlife.fss.or.kr/finlifeapi/rentHouseLoanProductsSearch.json?"
 	},
 	"fin_co_no": {
 		"020000": "은행",

--- a/findata/config.json
+++ b/findata/config.json
@@ -1,0 +1,74 @@
+{
+	"urls": {
+		"FIXED_DEPOSIT_URL": "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
+		"INSTALLMENT_DEPOSIT_URL": "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
+		"JEONSE_LOAN_URL": "http://finlife.fss.or.kr/finlifeapi/rentHouseLoanProductsSearch.json?"
+	},
+	"fin_co_no": {
+		"020000": "은행",
+		"030200": "여신전문",
+		"030300": "저축은행",
+		"050000": "보험회사",
+		"060000": "금융투자"
+	},
+	"tags": {
+		"fixed_deposit": {
+			"kor_co_nm": "금융회사명",
+			"fin_co_no": "금융회사코드",
+			"fin_prdt_nm": "금융상품명",
+			"fin_prdt_cd": "금융상품코드",
+			"join_member": "가입대상",
+			"join_way": "가입방법",
+			"mtrt_int": "만기후이자율",
+			"spcl_cnd": "우대조건",
+			"join_deny": "가입제한",
+			"max_limit": "최고한도",
+			"intr_rate_type_nm": "저축금리유형명",
+			"save_trm": "저축개월",
+			"intr_rate": "저축금리",
+			"intr_rate2": "최고우대금리",
+			"dcls_strt_day": "공시시작일",
+			"dcls_end_day": "공시종료일",
+			"dcls_month": "공시제출월"
+		},
+		"installment_deposit": {
+			"kor_co_nm": "금융회사명",
+			"fin_co_no": "금융회사코드",
+			"fin_prdt_nm": "금융상품명",
+			"fin_prdt_cd": "금융상품코드",
+			"join_member": "가입대상",
+			"join_way": "가입방법",
+			"mtrt_int": "만기후이자율",
+			"spcl_cnd": "우대조건",
+			"join_deny": "가입제한",
+			"max_limit": "최고한도",
+			"rsrv_type_nm": "적립유형명",
+			"intr_rate_type_nm": "저축금리유형명",
+			"save_trm": "저축개월",
+			"intr_rate": "저축금리",
+			"intr_rate2": "최고우대금리",
+			"dcls_strt_day": "공시시작일",
+			"dcls_end_day": "공시종료일",
+			"dcls_month": "공시제출월"
+		},
+		"jeonse_loan": {
+			"kor_co_nm": "금융회사명",
+			"fin_co_no": "금융회사코드",
+			"fin_prdt_nm": "금융상품명",
+			"fin_prdt_cd": "금융상품코드",
+			"join_way": "가입방법",
+			"loan_inci_expn": "대출부대비용",
+			"erly_rpay_fee": "중도상환수수료",
+			"dly_rate": "연체이자율",
+			"loan_lmt": "대출한도",
+			"rpay_type_nm": "대출상환유형",
+			"lend_rate_type_nm": "대출금리유형",
+			"lend_rate_min": "대출금리최저",
+			"lend_rate_max": "대출금리최고",
+			"lend_rate_avg": "전월취급평균금리",
+			"dcls_strt_day": "공시시작일",
+			"dcls_end_day": "공시종료일",
+			"dcls_month": "공시제출월"
+		}
+	}
+}

--- a/findata/config_manager.py
+++ b/findata/config_manager.py
@@ -1,0 +1,143 @@
+import json
+import os
+from easydict import EasyDict
+from pathlib import Path
+
+class JsonConfigManager:
+    """
+    Json설정파일을 관리
+    """
+
+    def __init__(self, **kwargs): # path
+        self.values = EasyDict()
+        if kwargs:
+            self.file_path = kwargs["path"]  # 파일경로 저장
+            self.reload()
+
+    def reload(self):
+        """
+        설정을 리셋하고 설정파일을 다시 로딩
+        """
+        self.clear()
+        if self.file_path:
+            with open(self.file_path, "r") as f:
+                self.values.update(json.load(f))
+
+    def clear(self):
+        """
+        설정을 리셋
+        """
+        self.values.clear()
+
+    def update(self, in_dict):
+        """
+        기존 설정에 새로운 설정을 업데이트한다(최대 3레벨까지만)
+        """
+        for k1, v1 in in_dict.items():
+            if isinstance(v1, dict):
+                for k2, v2 in v1.items():
+                    if isinstance(v2, dict):
+                        for k3, v3 in v2.items():
+                            self.values[k1][k2][k3] = v3
+                    else:
+                        self.values[k1][k2] = v2
+            else:
+                self.values[k1] = v1
+
+    def save(self, save_file_name):
+        """
+        설정값을 json파일로 저장
+        """
+
+        if save_file_name:
+            with open(save_file_name, "w", encoding="utf-8") as f:
+                json.dump(dict(self.values), f, ensure_ascii=False, indent="\t")
+
+
+
+if __name__=="__main__":
+    BASE_DIR = Path(__file__).resolve().parent.parent
+    jm = JsonConfigManager()
+    jm.values.urls = {
+        "FIXED_DEPOSIT_URL" : "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
+        "INSTALLMENT_DEPOSIT_URL" : "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
+        "JEONSE_LOAN_URL": "http://finlife.fss.or.kr/finlifeapi/rentHouseLoanProductsSearch.json?",
+    }
+
+    jm.values.fin_co_no = {
+        "020000": "은행",  # 은행
+        "030200": "여신전문",  # 여신전문
+        "030300": "저축은행",  # 저축은행
+        "050000": "보험회사",  # 보험회사
+        "060000": "금융투자",  # 금융투자
+    }
+    jm.values.tags = {}
+    jm.values.tags.fixed_deposit = {
+        "kor_co_nm": "금융회사명",  # 금융회사명
+        "fin_co_no": "금융회사코드",  # 금융회사코드
+        "fin_prdt_nm": "금융상품명",  # 금융상품명
+        "fin_prdt_cd": "금융상품코드",  # 금융상품코드
+        "join_member":	"가입대상", # 가입대상
+        "join_way": "가입방법",  # 가입방법
+        "mtrt_int": "만기후이자율",  # 만기후이자율
+        "spcl_cnd": "우대조건",  # 우대조건
+        "join_deny": "가입제한",  # 가입제한 1:제한X, 2:서민전용, 3:일부제한
+        "join_member": "가입대상",  # 가입대상
+        "max_limit": "최고한도",  # 최고한도
+        "intr_rate_type_nm": "저축금리유형명",  # 저축금리유형명
+        "save_trm": "저축개월",  # 저축개월 [단위: 개월]
+        "intr_rate": "저축금리",  # 저축금리 [소수점 2자리]
+        "intr_rate2": "최고우대금리",  # 최고우대금리
+        "dcls_strt_day": "공시시작일",  # 공시시작일
+        "dcls_end_day": "공시종료일",  # 공시종료일
+        "dcls_month": "공시제출월",  # 공시제출월
+    }
+
+    jm.values.tags.installment_deposit = {
+        "kor_co_nm": "금융회사명",  # 금융회사명
+        "fin_co_no": "금융회사코드",  # 금융회사코드
+        "fin_prdt_nm": "금융상품명",  # 금융상품명
+        "fin_prdt_cd": "금융상품코드",  # 금융상품코드
+        "join_member":	"가입대상", # 가입대상
+        "join_way": "가입방법",  # 가입방법
+        "mtrt_int": "만기후이자율",  # 만기후이자율
+        "spcl_cnd": "우대조건",  # 우대조건
+        "join_deny": "가입제한",  # 가입제한 1:제한X, 2:서민전용, 3:일부제한
+        "max_limit": "최고한도",  # 최고한도
+        "rsrv_type_nm": "적립유형명",  # 적립유형명
+        "intr_rate_type_nm": "저축금리유형명",  # 저축금리유형명
+        "save_trm": "저축개월",  # 저축개월 [단위: 개월]
+        "intr_rate": "저축금리",  # 저축금리 [소수점 2자리]
+        "intr_rate2": "최고우대금리",  # 최고우대금리
+        "dcls_strt_day": "공시시작일",  # 공시시작일
+        "dcls_end_day": "공시종료일",  # 공시종료일
+        "dcls_month": "공시제출월",  # 공시제출월
+    }
+    
+    jm.values.tags.jeonse_loan = {
+        "kor_co_nm": "금융회사명",  # 금융회사명d
+        "fin_co_no": "금융회사코드",  # 금융회사코드d
+        "fin_prdt_nm": "금융상품명",  # 금융상품명d
+        "fin_prdt_cd": "금융상품코드",  # 금융상품코드d
+        "join_way": "가입방법",  # 가입방법d
+        "loan_inci_expn": "대출부대비용",
+        "erly_rpay_fee": "중도상환수수료",
+        "dly_rate": "연체이자율",
+        "loan_lmt":	"대출한도",
+        "rpay_type_nm":	"대출상환유형",
+        "lend_rate_type_nm": "대출금리유형",
+        "lend_rate_min": "대출금리최저",
+        "lend_rate_max": "대출금리최고",
+        "lend_rate_avg": "전월취급평균금리",
+        "dcls_strt_day": "공시시작일",  # 공시시작일d
+        "dcls_end_day": "공시종료일",  # 공시종료일d
+        "dcls_month": "공시제출월",  # 공시제출월d
+    }
+
+    print(BASE_DIR)
+    jm.save(BASE_DIR / "findata" / "config.json")
+
+
+
+
+

--- a/findata/config_manager.py
+++ b/findata/config_manager.py
@@ -20,7 +20,7 @@ class JsonConfigManager:
         """
         self.clear()
         if self.file_path:
-            with open(self.file_path, "r") as f:
+            with open(self.file_path, "r", encoding="utf-8") as f:
                 self.values.update(json.load(f))
 
     def clear(self):

--- a/findata/config_manager.py
+++ b/findata/config_manager.py
@@ -1,14 +1,16 @@
 import json
 import os
-from easydict import EasyDict
 from pathlib import Path
+
+from easydict import EasyDict
+
 
 class JsonConfigManager:
     """
     Json설정파일을 관리
     """
 
-    def __init__(self, **kwargs): # path
+    def __init__(self, **kwargs):  # path
         self.values = EasyDict()
         if kwargs:
             self.file_path = kwargs["path"]  # 파일경로 저장
@@ -54,18 +56,17 @@ class JsonConfigManager:
                 json.dump(dict(self.values), f, ensure_ascii=False, indent="\t")
 
 
-
-if __name__=="__main__":
+if __name__ == "__main__":
     BASE_DIR = Path(__file__).resolve().parent.parent
     jm = JsonConfigManager()
     jm.values.category = {
         "정기예금": "fixed_deposit",
-        "적금": "installment_deposit", 
-        "전세대출": "jeonse_loan"
+        "적금": "installment_deposit",
+        "전세대출": "jeonse_loan",
     }
     jm.values.urls = {
-        "fixed_deposit" : "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
-        "installment_deposit" : "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
+        "fixed_deposit": "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
+        "installment_deposit": "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
         "jeonse_loan": "http://finlife.fss.or.kr/finlifeapi/rentHouseLoanProductsSearch.json?",
     }
 
@@ -82,7 +83,7 @@ if __name__=="__main__":
         "fin_co_no": "금융회사코드",  # 금융회사코드
         "fin_prdt_nm": "금융상품명",  # 금융상품명
         "fin_prdt_cd": "금융상품코드",  # 금융상품코드
-        "join_member":	"가입대상", # 가입대상
+        "join_member": "가입대상",  # 가입대상
         "join_way": "가입방법",  # 가입방법
         "mtrt_int": "만기후이자율",  # 만기후이자율
         "spcl_cnd": "우대조건",  # 우대조건
@@ -103,7 +104,7 @@ if __name__=="__main__":
         "fin_co_no": "금융회사코드",  # 금융회사코드
         "fin_prdt_nm": "금융상품명",  # 금융상품명
         "fin_prdt_cd": "금융상품코드",  # 금융상품코드
-        "join_member":	"가입대상", # 가입대상
+        "join_member": "가입대상",  # 가입대상
         "join_way": "가입방법",  # 가입방법
         "mtrt_int": "만기후이자율",  # 만기후이자율
         "spcl_cnd": "우대조건",  # 우대조건
@@ -118,7 +119,7 @@ if __name__=="__main__":
         "dcls_end_day": "공시종료일",  # 공시종료일
         "dcls_month": "공시제출월",  # 공시제출월
     }
-    
+
     jm.values.tags.jeonse_loan = {
         "kor_co_nm": "금융회사명",  # 금융회사명d
         "fin_co_no": "금융회사코드",  # 금융회사코드d
@@ -128,8 +129,8 @@ if __name__=="__main__":
         "loan_inci_expn": "대출부대비용",
         "erly_rpay_fee": "중도상환수수료",
         "dly_rate": "연체이자율",
-        "loan_lmt":	"대출한도",
-        "rpay_type_nm":	"대출상환유형",
+        "loan_lmt": "대출한도",
+        "rpay_type_nm": "대출상환유형",
         "lend_rate_type_nm": "대출금리유형",
         "lend_rate_min": "대출금리최저",
         "lend_rate_max": "대출금리최고",
@@ -140,8 +141,3 @@ if __name__=="__main__":
     }
 
     jm.save(BASE_DIR / "findata" / "config.json")
-
-
-
-
-

--- a/findata/config_manager.py
+++ b/findata/config_manager.py
@@ -58,10 +58,15 @@ class JsonConfigManager:
 if __name__=="__main__":
     BASE_DIR = Path(__file__).resolve().parent.parent
     jm = JsonConfigManager()
+    jm.values.category = {
+        "정기예금": "fixed_deposit",
+        "적금": "installment_deposit", 
+        "전세대출": "jeonse_loan"
+    }
     jm.values.urls = {
-        "FIXED_DEPOSIT_URL" : "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
-        "INSTALLMENT_DEPOSIT_URL" : "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
-        "JEONSE_LOAN_URL": "http://finlife.fss.or.kr/finlifeapi/rentHouseLoanProductsSearch.json?",
+        "fixed_deposit" : "http://finlife.fss.or.kr/finlifeapi/depositProductsSearch.json?",
+        "installment_deposit" : "http://finlife.fss.or.kr/finlifeapi/savingProductsSearch.json?",
+        "jeonse_loan": "http://finlife.fss.or.kr/finlifeapi/rentHouseLoanProductsSearch.json?",
     }
 
     jm.values.fin_co_no = {
@@ -134,7 +139,6 @@ if __name__=="__main__":
         "dcls_month": "공시제출월",  # 공시제출월d
     }
 
-    print(BASE_DIR)
     jm.save(BASE_DIR / "findata" / "config.json")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ distro==1.9.0
 Django==5.2.7
 django-environ==0.12.0
 dotenv==0.9.9
+easydict==1.13
 executing==2.2.1
 filelock==3.20.0
 FlagEmbedding==1.3.5
@@ -133,5 +134,3 @@ xxhash==3.6.0
 yarl==1.22.0
 zlib-state==0.1.10
 zstandard==0.25.0
-mysqlclient==2.2.4
-PyMySQL==1.1.1


### PR DESCRIPTION
### [[REFACTOR] 금융데이터 API 호출 추상화](https://github.com/13aek/finbot/issues/151)

### 작업 개요
api를 통한 금융 데이터 카테고리 별 추출을 원활하게 하기 위해 코드 추상화를 진행합니다.

### 변경 사항
- 세부 finance 컬럼 항목에 대한 configuration을 따로 두기
- config로 category 별 api 호출 가능하게 만들기

### 확인 요청
- [x] 코드 스타일(black, isort 등) 검사 통과  
- [x] 테스트 코드 실행 완료  
- [x] requirements.txt, findata/config.json 업데이트  
- [x] 환경변수 .env.example 업데이트 -> url을 config로 옮김
- [x] @youunaaaKim  DB설정도 참고하세요! 코드 test 확인하시면 comment 남기고 merge부탁드립니다!

### 참고 사항
- 관련 이슈: #29

### test 방법
- 가상환경 설정 및 install requirements.txt
- finbot 폴더(finbot/finbot 아님) 내에서 아래 코드 정상 동작 확인
1. 정기예금
```
python -m findata.call_findata_api -c fixed_deposit
```
<img width="481" height="223" alt="image" src="https://github.com/user-attachments/assets/162d011f-45c5-46e7-b3bf-cec008e4d93b" />

2. 적금
```
python -m findata.call_findata_api -c installment_deposit
```
<img width="475" height="217" alt="image" src="https://github.com/user-attachments/assets/016492d7-eb94-4bb2-9069-bb30f41e945c" />

3. 전세자금대출
```
python -m findata.call_findata_api -c jeonse_loan
```
<img width="482" height="205" alt="image" src="https://github.com/user-attachments/assets/b8838c72-c400-4e17-9846-a374c6d2b8b8" />
