### PR TITLE
[REFACTOR] 채팅 성능 개선

### DIFF
--- a/rag_flow/graph_flow.py
+++ b/rag_flow/graph_flow.py
@@ -30,6 +30,8 @@ def load_model_and_db():
     return get_ready_search()
 
 
+load_model_and_db()
+
 load_dotenv("../.env")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 

--- a/rag_flow/graph_flow.py
+++ b/rag_flow/graph_flow.py
@@ -12,10 +12,23 @@ from openai import OpenAI
 from sqlalchemy import create_engine
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
+from functools import lru_cache
+
 from FlagEmbedding import BGEM3FlagModel
 from qdrant_client import QdrantClient
 
 from findata.vectorDB import get_ready_search
+
+
+@lru_cache(maxsize=1)
+def load_model_and_db():
+    """
+    인자에 대한 반환값을 기억하여
+    해당 함수가 동일한 리턴값을 반환한다면
+    함수를 새로 실행시키는 것이 아닌 기억하고 있는 반환값을 그대로 사용합니다.
+    """
+    return get_ready_search()
+
 
 load_dotenv("../.env")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
@@ -31,7 +44,7 @@ class ChatSession:
 
     def __init__(self, user_history):
         self.state = {"visited": False, "history": []}
-        self.state["embed_model"], self.state["vectorDB"] = get_ready_search()
+        self.state["embed_model"], self.state["vectorDB"] = load_model_and_db()
 
         """
         DB에서 history 들고와서 저장해야함. 


### PR DESCRIPTION
### 작업 개요
- 임베딩 모델과 벡터 DB가 채팅 페이지 진입, 매 채팅 전송마다 로드되어 채팅 관련 기능의 동작이 매우 오래 걸리던 현상을 개선

### 변경 사항
변경 전 최초 채팅 페이지 방문 
<img width="140" height="15" alt="적용이전_Fh" src="https://github.com/user-attachments/assets/6201d107-1314-4969-95de-618859dee02b" />


변경 전 N번째 채팅 페이지 방문
<img width="132" height="26" alt="적용이전_Nh" src="https://github.com/user-attachments/assets/2dcbc833-2ec6-4eea-b809-29e5cc78b42c" />


변경 전 채팅 입력
<img width="135" height="21" alt="적용이전_예금질문" src="https://github.com/user-attachments/assets/fe50211d-45b8-49dc-b30a-779a831369f0" />


변경 후 최초 채팅 페이지 방문
<img width="145" height="15" alt="적용이후_Fh" src="https://github.com/user-attachments/assets/7b51c6c6-6480-4b19-9848-d5e0fe31e2bf" />


변경 후 N번째 채팅 페이지 방문
<img width="131" height="17" alt="적용이후_Nh" src="https://github.com/user-attachments/assets/4b70f4f1-4b3a-4a47-9431-e4391e8aa69a" />


변경 후 채팅 입력
<img width="125" height="23" alt="적용이후_예금질문" src="https://github.com/user-attachments/assets/446572e9-0915-482d-ae90-8639731b0cd5" />

### 확인 요청
- [x] 이전 로직들이 정상적으로 작동하는지 확인
- [x] 최초 서버 실행 이후 모델과 DB가 중복으로 로드되지 않는지 확인
https://github.com/13aek/finbot/pull/142 
<img width="539" height="172" alt="image" src="https://github.com/user-attachments/assets/5ba0e85e-c8e4-4822-b751-56095ec505b3" />
위 이미지가 서버 실행시에만 뜨면 정상입니다.


### 참고 사항
- 테스트 방법: 서버 실행 후 아래 페이지의 채팅 시나리오의 동작 확인
- 참고 링크: https://github.com/13aek/finbot/pull/142
