### PR TITLE
[REFACTOR] 추가 수집된 금융데이터 DB에 저장 및 중복 저장 방지

### DIFF
--- a/findata/main.py
+++ b/findata/main.py
@@ -9,19 +9,45 @@
 
 실행 명령어
 python -m findata.main
+
+모든 카테고리 저장 처리:
+1) fixed_deposit (정기예금)
+2) installment_deposit (적금)
+3) jeonse_loan (전세대출)
 """
 
 from findata.call_findata_api import fetch_findata
 from findata.save_to_db import save_fin_products
 
+
+FIN_CATEGORIES = [
+    ("fixed_deposit", "정기예금"),
+    ("installment_deposit", "적금"),
+    ("jeonse_loan", "전세자금대출"),
+]
+
+
 if __name__ == "__main__":
-    print("금융상품 API 데이터 수집 및 저장을 시작합니다.")
-    try:
-        data = fetch_findata()  # 금융상품 데이터 수집
-        if data:
-            save_fin_products(data)  # 수집된 데이터를 DB에 저장
-            print("전체 프로세스 완료.")
-        else:
-            print("수집된 데이터가 없습니다. API 응답을 확인하세요.")
-    except Exception as e:
-        print("실행 중 오류 발생:", e)
+    print("=== 금융상품 전체 데이터 수집 및 저장 프로세스 시작 ===")
+
+    for key, label in FIN_CATEGORIES:
+        print(f"\n>>> [{key}] {label} 데이터 수집 시작")
+    
+        try:
+            data = fetch_findata(category=key)  # 금융상품 데이터 수집
+        
+            # 각 상품에 category 키 추가
+            for d in data:
+                d["category"] = key
+
+            if data:
+                print(f"[{key}] {len(data)}건 수집 → DB 저장")
+                save_fin_products(data)
+                print(f"[{key}] 저장 완료")
+            else:
+                print(f"[{key}] 데이터 없음")
+
+        except Exception as e:
+            print(f"[오류] {key} 처리 중 오류:", e)
+
+    print("\n=== 전체 금융상품 수집/저장 프로세스 완료 ===")

--- a/findata/main.py
+++ b/findata/main.py
@@ -19,7 +19,6 @@ python -m findata.main
 from findata.call_findata_api import fetch_findata
 from findata.save_to_db import save_fin_products
 
-
 FIN_CATEGORIES = [
     ("fixed_deposit", "정기예금"),
     ("installment_deposit", "적금"),
@@ -32,10 +31,10 @@ if __name__ == "__main__":
 
     for key, label in FIN_CATEGORIES:
         print(f"\n>>> [{key}] {label} 데이터 수집 시작")
-    
+
         try:
             data = fetch_findata(category=key)  # 금융상품 데이터 수집
-        
+
             # 각 상품에 category 키 추가
             for d in data:
                 d["category"] = key

--- a/findata/save_to_db.py
+++ b/findata/save_to_db.py
@@ -71,7 +71,7 @@ def save_fin_products(data: List[Dict]) -> None:
         """
     )
 
-     # INSERT + UPDATE
+    # INSERT + UPDATE
     insert_query = """
         INSERT IGNORE INTO fin_products (
             category, company_type, company_name, product_name, product_code,
@@ -101,8 +101,6 @@ def save_fin_products(data: List[Dict]) -> None:
     inserted = 0
     updated = 0
 
-
-
     for idx, item in enumerate(data, start=1):
         # None / 누락 값 방지
         safe_item = {
@@ -123,19 +121,16 @@ def save_fin_products(data: List[Dict]) -> None:
 
         cursor.execute(insert_query, safe_item)
 
-
-
-
         # rowcount 동작 설명:
         # INSERT 실행 시:
         #   - 신규 INSERT → rowcount == 1
-        #   - ON DUPLICATE KEY UPDATE 발생 → rowcount == 2  
+        #   - ON DUPLICATE KEY UPDATE 발생 → rowcount == 2
         #       (MySQL의 ON DUPLICATE KEY UPDATE 특성: UPDATE가 발생하면 2로 반환)
 
         if cursor.rowcount == 1:
-            inserted += 1 # 신규 저장
+            inserted += 1  # 신규 저장
         elif cursor.rowcount == 2:
-            updated += 1 # 기존 데이터 업데이트
+            updated += 1  # 기존 데이터 업데이트
 
     conn.commit()
     print(f"MySQL INSERT: {inserted}건 / UPDATE: {updated}건")

--- a/findata/save_to_db.py
+++ b/findata/save_to_db.py
@@ -31,8 +31,9 @@ DB_NAME = os.getenv("DB_NAME")
 # 금융상품 데이터를 MySQL에 저장하는 함수
 def save_fin_products(data: List[Dict]) -> None:
     """
-    금융상품 데이터를 MySQL DB에 저장합니다.
-    :param data: fetch_findata()에서 반환된 List[Dict] 형식의 금융상품 데이터
+    금융상품 데이터를 MySQL DB에 저장
+    UNIQUE KEY(product_code, disclosure_month) 기준으로
+    기존 데이터가 있으면 UPDATE, 없으면 INSERT
     """
 
     # MySQL 연결 시작
@@ -53,47 +54,91 @@ def save_fin_products(data: List[Dict]) -> None:
         CREATE TABLE IF NOT EXISTS fin_products (
             id INT AUTO_INCREMENT PRIMARY KEY,
             company_type VARCHAR(50),
+            category VARCHAR(50),
             company_name VARCHAR(100),
             product_name VARCHAR(200),
             product_code VARCHAR(50),
-            maturity_interest TEXT,
-            conditions TEXT,
+            maturity_interest LONGTEXT,
+            conditions LONGTEXT,
             join_method VARCHAR(255),
             join_target VARCHAR(255),
             max_limit VARCHAR(255),
             disclosure_start VARCHAR(20),
             disclosure_end VARCHAR(20),
-            disclosure_month VARCHAR(10)
+            disclosure_month VARCHAR(10),
+            UNIQUE KEY unique_product_month (product_code, disclosure_month)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
         """
     )
 
-    # 데이터 삽입 쿼리
+     # INSERT + UPDATE
     insert_query = """
-        INSERT INTO fin_products (
-            company_type, company_name, product_name, product_code,
-            maturity_interest, conditions, join_method, join_target,
-            max_limit, disclosure_start, disclosure_end, disclosure_month
+        INSERT IGNORE INTO fin_products (
+            category, company_type, company_name, product_name, product_code,
+            join_method, join_target, max_limit,
+            maturity_interest, conditions,
+            disclosure_start, disclosure_end, disclosure_month
         ) VALUES (
-            %(회사유형)s, %(금융회사명)s, %(금융상품명)s, %(금융상품코드)s,
-            %(만기후이자율)s, %(우대조건)s, %(가입방법)s, %(가입대상)s,
-            %(최고한도)s, %(공시시작일)s, %(공시종료일)s, %(공시제출월)s
+            %(category)s, %(회사유형)s, %(금융회사명)s, %(금융상품명)s, %(금융상품코드)s,
+            %(가입방법)s, %(가입대상)s, %(최고한도)s,
+            %(만기후이자율)s, %(우대조건)s,
+            %(공시시작일)s, %(공시종료일)s, %(공시제출월)s
         )
+        ON DUPLICATE KEY UPDATE
+            company_type = VALUES(company_type),
+            company_name = VALUES(company_name),
+            product_name = VALUES(product_name),
+            join_method = VALUES(join_method),
+            join_target = VALUES(join_target),
+            max_limit = VALUES(max_limit),
+            maturity_interest = VALUES(maturity_interest),
+            conditions = VALUES(conditions),
+            disclosure_start = VALUES(disclosure_start),
+            disclosure_end = VALUES(disclosure_end)
     """
 
     # 데이터 삽입
     inserted = 0
-    for item in data:
-        try:
-            cursor.execute(insert_query, item)
-            inserted += 1
-        except Exception as e:
-            print("Insert Error:", e)  # 오류 발생 시 출력
-            continue  # 다음 데이터로 진행
+    updated = 0
+
+
+
+    for idx, item in enumerate(data, start=1):
+        # None / 누락 값 방지
+        safe_item = {
+            "category": item.get("category", "") or "",
+            "회사유형": item.get("회사유형", "") or "",
+            "금융회사명": item.get("금융회사명", "") or "",
+            "금융상품명": item.get("금융상품명", "") or "",
+            "금융상품코드": item.get("금융상품코드", "") or "",
+            "만기후이자율": item.get("만기후이자율", "") or "",
+            "우대조건": item.get("우대조건", "") or "",
+            "가입방법": item.get("가입방법", "") or "",
+            "가입대상": item.get("가입대상", "") or "",
+            "최고한도": item.get("최고한도", "") or "",
+            "공시시작일": item.get("공시시작일", "") or "",
+            "공시종료일": item.get("공시종료일", "") or "",
+            "공시제출월": item.get("공시제출월", "") or "",
+        }
+
+        cursor.execute(insert_query, safe_item)
+
+
+
+
+        # rowcount 동작 설명:
+        # INSERT 실행 시:
+        #   - 신규 INSERT → rowcount == 1
+        #   - ON DUPLICATE KEY UPDATE 발생 → rowcount == 2  
+        #       (MySQL의 ON DUPLICATE KEY UPDATE 특성: UPDATE가 발생하면 2로 반환)
+
+        if cursor.rowcount == 1:
+            inserted += 1 # 신규 저장
+        elif cursor.rowcount == 2:
+            updated += 1 # 기존 데이터 업데이트
 
     conn.commit()
-    print(f"MySQL에 {inserted}건 저장 완료")
+    print(f"MySQL INSERT: {inserted}건 / UPDATE: {updated}건")
 
-    # 연결 종료
     cursor.close()
     conn.close()


### PR DESCRIPTION
### 작업 개요
카테고리별 금융상품 데이터 수집/저장 로직 정비하고, 중복 저장 문제를 해결

### 변경 사항
- product_code(금융상품코드) + disclosure_month(공시제출월) 기반 UNIQUE KEY 적용
- 중복 저장 방지를 위한 ON DUPLICATE KEY UPDATE 로직 구현
- 기존 INSERT 방식 개선 → 신규는 삽입 / 기존은 갱신
- category(fixed_deposit, installment_deposit, jeonse_loan) 표준화
- main.py 카테고리별 수집/저장 정상작동 확인
- 주석/가독성 개선

### 확인 요청
 - [x] 코드 스타일(black, isort 등) 검사 통과
 - [x]  금융상품 데이터 3종 카테고리 정상 수집 및 저장
 - [x]  중복 저장 테스트 → 신규 insert / 조건 변경 시 update 정상 동작
 - [x]  리뷰어가 이해할 수 있도록 주석 및 로직 설명 추가

### 참고 사항
- 관련 이슈: 
#160
#152

---

- 테스트 방법

0. MySQL 설치, 원격 연결
MySQL 설치 가이드 #54 
MySQL 원격 접속 가이드 #92



1. .env에 정보 입력
2. 가상환경 활성화
```
python -m venv venv
source venv/Scripts/activate
```
3. 필수 패키지 설치
```
pip install -r requirements.txt
pip list
```


4. 스크립트 실행
```
python -m findata.main
```

5. 성공 로그 확인

6. DB 확인(MySQL)에서
```
SELECT *
FROM fin_products 
ORDER BY category;
```
<img width="2152" height="1290" alt="image" src="https://github.com/user-attachments/assets/3f5ae9a5-c792-48b7-a42b-6c66d8496111" />
