### PR TITLE
[FIX] search.html 조건문 중복 종료 코드 복구

### DIFF
--- a/products/templates/products/search.html
+++ b/products/templates/products/search.html
@@ -93,6 +93,7 @@
           <p>검색 결과가 없습니다.</p>
         </div>
         {% endif %}
+      {% endif %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
### 작업 개요
`search.html` 조건문 중복 종료 코드 복구

### 변경 사항
- `search.html` 내 삭제하였던 `{% endif %}` 코드 복구

### 확인 요청
<img width="1257" height="290" alt="image" src="https://github.com/user-attachments/assets/e9199444-a95e-4e59-b80a-e25803ff4cd3" />

<br>

- [ ] `http://127.0.0.1:8000/products/search/`에서 검색어 입력 시 데이터 출력 여부 확인
  - 사진과 같은 `TemplateSyntaxError`가 발생하지 않아야 합니다.

### 참고 사항
- 관련 이슈: #203
- 테스트 방법: `python manage.py runserver`
