### PR TITLE
[REFACTOR] 오타수정 및 홈페이지 url 변경

### DIFF
--- a/chatbot/urls.py
+++ b/chatbot/urls.py
@@ -6,7 +6,7 @@ from . import views
 app_name = "chat"
 
 urlpatterns = [
-    path("", views.chat_page, name="currnet_chat"),  # 가장 최근의 채팅 페이지
+    path("", views.chat_page, name="current_chat"),  # 가장 최근의 채팅 페이지
     path("<int:chatroom_pk>/", views.chat_page, name="chat_page"),  # 대화 페이지
     path("chatlist/", views.chat_list, name="chat_list"),  # 모든 채팅방 조회 페이지
     path("chatroom/create/", views.chatroom_create, name="chatroom_create"),  # 채팅방 생성

--- a/chatbot/views.py
+++ b/chatbot/views.py
@@ -49,7 +49,7 @@ def chatroom_delete(requset, chatroom_pk):
     if chatroom.user == requset.user:
         chatroom.delete()
         # 가장 최근의 채팅방으로 리다이렉트
-        return redirect("chat:currnet_chat")
+        return redirect("chat:current_chat")
 
 
 @login_required

--- a/finbot/urls.py
+++ b/finbot/urls.py
@@ -22,6 +22,6 @@ from django.urls import include, path
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("accounts/", include("accounts.urls")),
-    path("products/", include("products.urls")),
+    path("", include("products.urls")),
     path("chat/", include("chatbot.urls")),
 ]

--- a/products/templates/products/index.html
+++ b/products/templates/products/index.html
@@ -104,7 +104,7 @@
   </section>
 
   {# 채팅 페이지 버튼 #}
-  <a href="{% url 'chat:currnet_chat' %}" class="chatbot-btn">
+  <a href="{% url 'chat:current_chat' %}" class="chatbot-btn">
     <img src="{% static 'images/finbot.png' %}" alt="FINBOT Chat">
   </a>
 </main>

--- a/products/templates/products/search.html
+++ b/products/templates/products/search.html
@@ -21,7 +21,7 @@
 
     <div class="right-group">
       {% if request.user.is_authenticated %}
-        <a href="{% url 'chat:currnet_chat' %}" class="info-btn">AI CHAT</a>
+        <a href="{% url 'chat:current_chat' %}" class="info-btn">AI CHAT</a>
         <a href="{% url 'accounts:update' %}" class="info-btn">회원 정보</a>
         {# <a href="{% url 'accounts:bookmark' %}" class="info-btn">관심 상품</a> #}
         <a href="{% url 'accounts:logout' %}" class="logout-btn">로그아웃</a>


### PR DESCRIPTION
### 작업 개요
오타 수정과 메인 페이지 url 변

### 변경 사항
- hatbot/views.py의 chatroom_delete 함수의 오타를 수정하였습니다.
  - return redirect("chat:currnet_chat") -> return redirect("chat:current_chat")
- 홈페이지 url을 product 페이지가 뜨도록 수정했습니다.

### 확인 요청
- [x] 서버 실행 후 첫 페이지가 product 페이지인지 확인
- [x] 채팅 페이지 정상 접속 가능 확인
- 메인 페이지 채팅
<img width="2550" height="1270" alt="image" src="https://github.com/user-attachments/assets/f131b5bc-28ad-46b2-9e49-e7352ef98b77" />
- 검색 페이지 채팅
<img width="2552" height="1259" alt="image" src="https://github.com/user-attachments/assets/5d36193d-f5bb-4fbf-82b3-74d2e8aeb31e" />

위 페이지에서 오류가 나지 않는다면 정상입니다.

