### PR TITLE
[FIX] Pretendard 폰트 로딩 방식 변경

### DIFF
--- a/accounts/static/accounts/css/auth-layout.css
+++ b/accounts/static/accounts/css/auth-layout.css
@@ -8,7 +8,7 @@ body {
     margin: 0;
     padding: 0;
     background-color: #F3F3F3;
-    font-family: 'Pretendard Variable', sans-serif;
+    font-family: 'Pretendard', sans-serif;
     height: 100vh;
     display: flex; 
     justify-content: center;
@@ -55,7 +55,7 @@ form button {
     padding: 0 20px;
     font-size: 15px;
     box-sizing: border-box;
-    font-family: 'Pretendard Variable', sans-serif;
+    font-family: 'Pretendard', sans-serif;
 }
 
 form input:focus {

--- a/accounts/static/accounts/css/mypage-layout.css
+++ b/accounts/static/accounts/css/mypage-layout.css
@@ -94,6 +94,7 @@ input::placeholder {
 /* 3. 버튼 공통 스타일 */
 /* ----------------- */
 button {
+  font-family: 'Pretendard', sans-serif;
   background-color: #3F72AF;
   color: #FFFFFF;
   border: none;

--- a/accounts/static/accounts/css/mypage-layout.css
+++ b/accounts/static/accounts/css/mypage-layout.css
@@ -8,7 +8,7 @@
 html, body {
   height: 100%;
   background-color: #FFFFFF;
-  font-family: 'Pretendard Variable', sans-serif;
+  font-family: 'Pretendard', sans-serif;
 }
 
 /* 컨테이너 */
@@ -76,7 +76,7 @@ form input:focus {
 }
 
 input, select {
-  font-family: 'Pretendard Variable', sans-serif;
+  font-family: 'Pretendard', sans-serif;
   border: 1px solid #E5E5E5;
   border-radius: 30px;
   background-color: #FFFFFF;

--- a/chatbot/static/chatbot/css/chat.css
+++ b/chatbot/static/chatbot/css/chat.css
@@ -2,7 +2,7 @@
         margin: 0;
         padding: 20px;
         background-color: #FFFFFF;
-        font-family: 'Pretendard Variable', sans-serif;
+        font-family: 'Pretendard', sans-serif;
         height: 100vh;
         display: flex;
         overflow: hidden;
@@ -255,7 +255,7 @@
         resize: none; 
         box-sizing: border-box;
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-        font-family: 'Pretendard Variable', sans-serif;
+        font-family: 'Pretendard', sans-serif;
 }
 
 /* 호버 시 색상 변경 없음 */

--- a/products/static/products/css/index.css
+++ b/products/static/products/css/index.css
@@ -2,7 +2,7 @@ body {
     margin: 0;
     padding: 0;
     background-color: #FFFFFF;
-    font-family: 'Pretendard Variable', sans-serif;
+    font-family: 'Pretendard', sans-serif;
     height: 100vh;
     display: flex;
     flex-direction: column;
@@ -125,7 +125,7 @@ body {
     background: none;
     font-size: 16px;
     color: #000000;
-    font-family: 'Pretendard Variable', sans-serif;
+    font-family: 'Pretendard', sans-serif;
 }
 
 .search-input::placeholder {

--- a/products/static/products/css/search.css
+++ b/products/static/products/css/search.css
@@ -1,6 +1,6 @@
 body {
     background-color: #F3F3F3;
-    font-family: 'Pretendard Variable', sans-serif;
+    font-family: 'Pretendard', sans-serif;
 }
 
 .content-wrapper {
@@ -93,7 +93,7 @@ body {
     background: none;
     font-size: 16px;
     color: #000000;
-    font-family: 'Pretendard Variable', sans-serif;
+    font-family: 'Pretendard', sans-serif;
 }
 
 .search-input::placeholder {

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,7 +14,7 @@
   <title>Finbot</title>
 
   {# 폰트 적용 #}
-  <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css" />
+  <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css" />
 
   {# 각 html 별 스타일이 들어갈 공간 #}
   {% block styles %}


### PR DESCRIPTION
### 작업 개요
일부 로컬 환경에서 `Pretendard Variable` 폰트가 정상적으로 로딩되지 않는 문제 확인
안정적인 렌더링을 위해 기존 `dynamic-subset` 방식에서 `static` 방식으로 전환

<br>

### 변경 사항
- `base.html` 내 Pretendard CDN 링크 수정
  - `dynamic-subset` →  `static`

<br>

- CSS 파일의 `font-family` 수정
  - `Pretendard Variable` → `Pretendard`

<br>

- `mypage-layout.css` 버튼에 `font-family` 적용

<br>

### 확인 요청
<img width="774" height="368" alt="image" src="https://github.com/user-attachments/assets/1e37e481-ec62-48d6-9bf6-be7b49e7ec76" />

- [x] 모든 페이지의 개발자 도구 (`F12`) → Elements → Computed → font-family 'Pretendard' 출력 확인
  - 기존 폰트 `Noto Sans Kr` 또는 `Malgun Gothic` 등 다른 폰트의 출력 여부 확인
  - 혹시 다른 폰트가 출력되는 페이지가 있다면 알려주세요

<br>

<img width="307" height="83" alt="image" src="https://github.com/user-attachments/assets/34b1ef1e-efc7-4cf5-a58d-2354868a6b4e" />

- [x] 특정 페이지의 개발자 도구 (`F12`) → Select an element → Elements → Computed → Rendered Fonts → Font 'Pretendard' 출력 확인
  - `accounts/update/` 페이지의 '정보 수정' 버튼
  - `accounts/password/` 페이지의 '비밀번호 변경' 버튼
  - 페이지 전체를 살피는 위의 요청과 달리, 버튼을 개별적으로 선택하여 확인해야 합니다

<br>

### 참고 사항
- 관련 이슈: #221
- 테스트 방법: `python manage.py runserver` 후 개발자 도구 실행
