### PR TITLE
[FEAT] 챗봇에게 응답받은 상품을 채팅 페이지에서 북마크 할 수 있도록 하는 기능 구현

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -316,7 +316,6 @@ def bookmark(request, product_code):
     # 만약 url을 브라우저에 직접 입력해서 보냈다면 메인 페이지로 리다이렉트합니다.
     if not next_url:
         next_url = "products:index"
-    print(next_url)
     return redirect(next_url)
 
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -311,7 +311,13 @@ def bookmark(request, product_code):
         product.users.remove(request.user)
     else:
         product.users.add(request.user)
-    return redirect("products:index")
+    # 상품 검색 페이지나 채팅 페이지에서 북마크 요청을 보낸 경우 요청을 보낸 페이지로 리다이렉트합니다.
+    next_url = request.POST.get("next")
+    # 만약 url을 브라우저에 직접 입력해서 보냈다면 메인 페이지로 리다이렉트합니다.
+    if not next_url:
+        next_url = "products:index"
+    print(next_url)
+    return redirect(next_url)
 
 
 @login_required

--- a/chatbot/templates/chatbot/chat.html
+++ b/chatbot/templates/chatbot/chat.html
@@ -91,6 +91,8 @@
                 {# 북마크 버튼 구현 #}
                 <form action="{% url "accounts:bookmark" msg.product.fin_prdt_cd %}" method="POST">
                   {% csrf_token %}
+                  {# 북마크를 요청한 페이지로 리다이렉트 되도록 서버에 현재 url을 담아서 보냄 #}
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
                   {# 사용자의 북마크 여부에 따라 출력되는 텍스트를 다르게 구현 #}
                   {% if request.user in msg.product.users.all %}
                     <input type="submit" value="북마크 취소">

--- a/chatbot/templates/chatbot/chat.html
+++ b/chatbot/templates/chatbot/chat.html
@@ -88,6 +88,16 @@
                 상품 이름: {{ msg.product.fin_prdt_nm}}
                 은행: {{ msg.product.kor_co_nm }}
                 설명: {{ msg.product.description }}
+                {# 북마크 버튼 구현 #}
+                <form action="{% url "accounts:bookmark" msg.product.fin_prdt_cd %}" method="POST">
+                  {% csrf_token %}
+                  {# 사용자의 북마크 여부에 따라 출력되는 텍스트를 다르게 구현 #}
+                  {% if request.user in msg.product.users.all %}
+                    <input type="submit" value="북마크 취소">
+                  {% else %}
+                    <input type="submit" value="북마크">
+                  {% endif %}
+                </form>
               </div>
             </div>
           {% else %}


### PR DESCRIPTION
### 작업 개요
챗봇에게 추천받은 상품을 채팅 페이지에서 즉석으로 북마크 할 수 있도록 기능을 구현하였습니다.

### 변경 사항
- 채팅 페이지에서 사용자가 상품 추천을 받았다면 상품 정보와 함께 북마크 버튼을 출력
- 채팅 페이지에서 북마크 버튼을 누르면 채팅 페이지로 리다이렉트 되도록 설정

### 확인 요청
- [x] 채팅 페이지에서 금융 상품 추천 요청
- [x] 북마크 버튼 클릭
- [x] 북마크 버튼 클릭 후 채팅 페이지로 리다이렉트되는지 확인
<img width="1153" height="385" alt="image" src="https://github.com/user-attachments/assets/01d4f910-a38b-46a5-a7b2-ae83862b3bb0" />
<img width="768" height="294" alt="image" src="https://github.com/user-attachments/assets/2646dd36-f10f-4d1d-ac86-ad2d217c4856" />

