### PR TITLE
[FEAT] 메인 페이지 로그인 유저 관심 상품 출력

### DIFF
--- a/products/templates/products/index.html
+++ b/products/templates/products/index.html
@@ -48,30 +48,69 @@
     <h2 class="recommend-title">
       사용자님의 <span class="highlight-title">관심 상품</span>
     </h2>
-
-    <div class="card-container">
-      <div class="rec-card">
-        <div class="rec-card-inner">
-          <h3>NH 고향사랑기부적금</h3>
-          <p>고향 발전을 위한 기부금도 쌓고, 우대금리도 받고!</p>
+      {% if page_obj %}
+        <div class="card-container">
+          {% for product in page_obj %}
+          
+            <div class="rec-card">
+              <div class="rec-card-inner">
+                <h3>{{ product.fin_prdt_nm }}</h3>
+                <p>{{ product.description }}</p>
+              </div>
+            </div>
+          {% endfor %}
         </div>
-      </div>
+        <div class="pagination">
+          {# 이전 페이지 #}
+          {% if show_previous_10 %}
+            <a href="?query={{ query }}&page={{ previous_page }}">이전</a>
+          {% endif %}
 
-      <div class="rec-card">
-        <div class="rec-card-inner">
-          <h3>신한 안녕, 반가워 적금</h3>
-          <p>새롭게 금융 거래를 시작하는 고객님을 위해 준비했어요.</p>
-        </div>
-      </div>
+          {# 페이지 번호 그룹 표시 (1부터 10까지) #}
+          {% for num in page_obj.paginator.page_range %}
+            {% if num >= start_page and num <= end_page %}
+              {% if num == page_obj.number %}
+                <span>{{ num }}</span>
+              {% else %}
+                <a href="?query={{ query }}&page={{ num }}">{{ num }}</a>
+              {% endif %}
+            {% endif %}
+          {% endfor %}
 
-      <div class="rec-card">
-        <div class="rec-card-inner">
-          <h3>WON 적금</h3>
-          <p>복잡하지 않고 간단한 적금</p>
+          {# 다음 페이지 #}
+          {% if show_next_10 %}
+            <a href="?query={{ query }}&page={{ next_page }}">다음</a>
+          {% endif %}
         </div>
-      </div>
-    </div>
-    
+      {% else %}
+        <h2 class="recommend-title">
+          고객님께 추천해 드리는 <span class="highlight-title">금주의 상품</span>
+        </h2>
+
+        <div class="card-container">
+          <div class="rec-card">
+            <div class="rec-card-inner">
+              <h3>NH 고향사랑기부적금</h3>
+              <p>고향 발전을 위한 기부금도 쌓고, 우대금리도 받고!</p>
+            </div>
+          </div>
+
+          <div class="rec-card">
+            <div class="rec-card-inner">
+              <h3>신한 안녕, 반가워 적금</h3>
+              <p>새롭게 금융 거래를 시작하는 고객님을 위해 준비했어요.</p>
+            </div>
+          </div>
+
+          <div class="rec-card">
+            <div class="rec-card-inner">
+              <h3>WON 적금</h3>
+              <p>복잡하지 않고 간단한 적금</p>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+
     {% else %}
     {# 비로그인 사용자 #}
     <h2 class="recommend-title">

--- a/products/views.py
+++ b/products/views.py
@@ -22,7 +22,35 @@ def index(request):
     Returns:
         HttpResponse: 검색창이 포함된 'products/search.html' 템플릿 렌더링 결과
     """
-    return render(request, "products/index.html")
+    bookmarked = []
+    if request.user.is_authenticated:
+        bookmarked = request.user.products.all()
+    # return render(request, "products/index.html", {"bookmarked": bookmarked})
+    # 페이지당 상품 수: 3
+    # 페이지네이션 그룹 단위: 10
+    paginator = Paginator(bookmarked, 3)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+
+    current_page = page_obj.number
+    start_page = ((current_page - 1) // 10) * 10 + 1
+    end_page = min(start_page + 9, paginator.num_pages)
+
+    previous_page = max(current_page - 1, 1)
+    next_page = min(current_page + 1, paginator.num_pages)
+
+    show_previous_10 = current_page > 1  # 이전 10개 버튼을 표시할지 여부
+    show_next_10 = current_page < paginator.num_pages
+    context = {
+        "page_obj": page_obj,
+        "start_page": start_page,
+        "end_page": end_page,
+        "previous_page": previous_page,
+        "next_page": next_page,
+        "show_previous_10": show_previous_10,
+        "show_next_10": show_next_10,
+    }
+    return render(request, "products/index.html", context)
 
 
 def search(request):


### PR DESCRIPTION
### 작업 개요
로그인 유저의 관심상품을 메인 페이지에 출력

### 변경 사항
- 메인 페이지에 로그인 유저의 관심 상품 출력
- 메인 페이지 페이지네이션 구현

### 확인 요청
<로그인 시>
- [x] 묵마크 추가 시 메인 페이지에 출력됨(상품 이름, 디스크립션)
- [x] 메인 페이지 한페이지에 3개의 상품 출력, 그 이상은 다음 페이지로 넘어가며, 페이지인덱스 출력
- [x] 페이지네이션 정상 작동 확인
- [x] 관심 상품 없을 때: 비로그인 유저와 동일하게 출력

### 참고 사항
- 관련 이슈: #246 
- 일단 제가 임의로 한페이지에 3개의 상품 출력/페이지인덱스 단위는 10으로 구성해 놓았는데요. 변경 필요하시면 말씀해주세요! @psychewooo 
