### PR TITLE
[FEAT] 북마크 리스트 페이지 페이지네이션 적용

### DIFF
--- a/accounts/templates/accounts/bookmark_list.html
+++ b/accounts/templates/accounts/bookmark_list.html
@@ -37,6 +37,15 @@
             <p class="product-name">{{ product.fin_prdt_nm }}</p>
             <p style="font-weight: bold">{{ product.kor_co_nm }}</p>
             <p>{{ product.description }}</p>
+            <form method="POST" action="{% url 'accounts:bookmark' product.fin_prdt_cd %}">
+            {% csrf_token %}
+            <input type="hidden" name="next" value="{{ request.get_full_path }}">
+            {% if request.user in product.users.all %}
+              <input type="submit" class="bookmark-btn bookmarked" value='북마크 해제'>
+            {% else %}
+              <input type="submit" class="bookmark-btn" value='북마크'>
+            {% endif %}
+          </form>
           </div>
         {% endfor %}
 

--- a/accounts/templates/accounts/bookmark_list.html
+++ b/accounts/templates/accounts/bookmark_list.html
@@ -31,19 +31,41 @@
     </h2>
 
     <div class="product-container">
-      {% if products %}
-      {% for product in products %}
-      <div class="bookmark-item">
-        <p class="product-name">{{ product.fin_prdt_nm }}</p>
-          <p style="font-weight: bold">{{ product.kor_co_nm }}</p>
-          <p>{{ product.description }}</p>
-      </div>
-    {% endfor %}
+      {% if page_obj %}
+        {% for product in page_obj %}
+          <div class="bookmark-item">
+            <p class="product-name">{{ product.fin_prdt_nm }}</p>
+            <p style="font-weight: bold">{{ product.kor_co_nm }}</p>
+            <p>{{ product.description }}</p>
+          </div>
+        {% endfor %}
 
-    {% else %}
-      <p class="no-item">아직 등록한 관심 상품이 없습니다.
+        <div class="pagination">
+          {# 이전 페이지 #}
+          {% if show_previous_5 %}
+            <a href="?query={{ query }}&page={{ previous_page }}">이전</a>
+          {% endif %}
+
+          {# 페이지 번호 그룹 표시 (1부터 5까지) #}
+          {% for num in page_obj.paginator.page_range %}
+          {% if num >= start_page and num <= end_page %}
+          {% if num == page_obj.number %}
+          <span>{{ num }}</span>
+          {% else %}
+            <a href="?query={{ query }}&page={{ num }}">{{ num }}</a>
+          {% endif %}
+          {% endif %}
+          {% endfor %}
+
+          {# 다음 페이지 #}
+          {% if show_next_5 %}
+            <a href="?query={{ query }}&page={{ next_page }}">다음</a>
+          {% endif %}
+        </div>
+      {% else %}
+        <p class="no-item">아직 등록한 관심 상품이 없습니다.
         마음에 드는 상품을 추가해 보세요.</p>
-    {% endif %}
+      {% endif %}
     </div>
   </div>
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -7,6 +7,7 @@ from django.contrib.auth import (
 )
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import AuthenticationForm, PasswordChangeForm
+from django.core.paginator import Paginator
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils import timezone
@@ -336,4 +337,28 @@ def bookmark_list(request):
     """
     # 해당 사용자가 북마크한 모든 상품을 조회합니다.
     products = FinProduct.objects.filter(users=request.user)
-    return render(request, "accounts/bookmark_list.html", {"products": products})
+    # 페이지당 상품 수: 6
+    # 페이지네이션 그룹 단위: 5
+    paginator = Paginator(products, 6)
+    page_number = request.GET.get("page")
+    page_obj = paginator.get_page(page_number)
+
+    current_page = page_obj.number
+    start_page = ((current_page - 1) // 5) * 5 + 1
+    end_page = min(start_page + 4, paginator.num_pages)
+
+    previous_page = max(current_page - 1, 1)
+    next_page = min(current_page + 1, paginator.num_pages)
+
+    show_previous_5 = current_page > 1
+    show_next_5 = current_page < paginator.num_pages
+    context = {
+        "page_obj": page_obj,
+        "start_page": start_page,
+        "end_page": end_page,
+        "previous_page": previous_page,
+        "next_page": next_page,
+        "show_previous_5": show_previous_5,
+        "show_next_5": show_next_5,
+    }
+    return render(request, "accounts/bookmark_list.html", context)


### PR DESCRIPTION
### 작업 개요
북마크 리스트 페이지 페이지네이션 적용

### 변경 사항
- 북마크 리스트 페이지 페이지네이션 구현
- 북마크 리스트 페이지 북마크 해제 버튼 추가

### 확인 요청
<로그인 상태로 다량의 북마크를 설정해놓고 테스트해주세요>
- [x] 관심상품 페이지에서 한페이지에 북마크한 상품 6개씩 출력, 페이지 인덱스는 5단위로 출력
- [x] 페이지 이동이 원활한지 확인
- [x] 북마크한 상품의 북마크 해제 버튼 확인
- [x] 북마크 해제시 북마크 리스트에서도 사라짐

### 참고 사항
- 관련 이슈: #256 