### PR TITLE
[STYLE] 채팅 페이지 내 북마크 기능 UI 개선

### DIFF
--- a/chatbot/static/chatbot/css/chat.css
+++ b/chatbot/static/chatbot/css/chat.css
@@ -332,3 +332,72 @@ body {
     background-color: transparent;
     color: #000000; 
 }
+
+
+/* ----------- */
+/* 5. 상품 추천 */
+/* ----------- */
+/* 상품 추천 카드 */
+.recommend-message .bubble {
+  display: flex;
+  flex-direction: column;
+  background-color: #FFFFFF;
+  color: #000;
+  border: 1px solid #E0E0E0;
+  border-radius: 20px;
+  border-bottom-left-radius: 0;
+  align-items: flex-start;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
+  padding: 30px;
+}
+
+/* 상단 (추천 문구 + 북마크) */
+.recommend-header {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 15px;
+}
+
+.recommend-title {
+    font-weight: 700;
+    font-size: 16px;
+    margin: 0;
+}
+
+.recommend-grid {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    row-gap: 15px;
+    font-size: 16px;
+}
+
+.recommend-label {
+    font-weight: 700;
+}
+
+/* 북마크 버튼 */
+.bookmark-btn {
+    display: flex;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+    color: #A9A9A9;
+    align-items: center;
+    line-height: 0;
+}
+
+.bookmark-btn svg {
+    width: 25px;
+    height: 25px;
+}
+
+.bookmark-btn.bookmarked {
+    color: #FFBF30;
+}
+
+.bookmark-btn:not(.bookmarked) svg {
+    transform: scale(0.92);
+    transform-origin: center;
+}

--- a/chatbot/templates/chatbot/chat.html
+++ b/chatbot/templates/chatbot/chat.html
@@ -138,25 +138,42 @@
       {# 채팅 봇의 메시지 #}
         {# 만약 추천 상품이 담겨있는 채팅이라면 #}
         {% if msg.product %}
-          <div class="message-container bot-message">
+          <div class="message-container recommend-message">
             <div class="bubble">
-              {{ msg.message }}
-              상품 이름: {{ msg.product.fin_prdt_nm}}
-              은행: {{ msg.product.kor_co_nm }}
-              설명: {{ msg.product.description }}
+              <div class="recommend-header">
+                <p class="recommend-title">{{ msg.message }}</p>
+                {# 북마크 버튼 #}
+                <form action="{% url "accounts:bookmark" msg.product.fin_prdt_cd %}" method="POST">
+                  {% csrf_token %}
+                  {# 북마크를 요청한 페이지로 리다이렉트 되도록 서버에 현재 url을 담아서 보냄 #}
+                  <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                  {# 사용자의 북마크 여부에 따라 출력되는 텍스트를 다르게 구현 #}
+                  {% if request.user in msg.product.users.all %}
+                    <button type="submit" class="bookmark-btn bookmarked">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 3.5l2.3 4.7 5.2.8-3.8 3.7.9 5.2L12 15.8l-4.6 2.4.9-5.2-3.8-3.7 5.2-.8L12 3.5z" fill="currentColor">
+                      </svg>
+                    </button>
+                  {% else %}
+                    <button type="submit" class="bookmark-btn">
+                      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M12 3.5l2.3 4.7 5.2.8-3.8 3.7.9 5.2L12 15.8l-4.6 2.4.9-5.2-3.8-3.7 5.2-.8L12 3.5z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round">
+                      </svg>
+                    </button>
+                  {% endif %}
+                </form>
+              </div>
 
-              {# 북마크 버튼 #}
-              <form action="{% url "accounts:bookmark" msg.product.fin_prdt_cd %}" method="POST">
-                {% csrf_token %}
-                {# 북마크를 요청한 페이지로 리다이렉트 되도록 서버에 현재 url을 담아서 보냄 #}
-                <input type="hidden" name="next" value="{{ request.get_full_path }}">
-                {# 사용자의 북마크 여부에 따라 출력되는 텍스트를 다르게 구현 #}
-                {% if request.user in msg.product.users.all %}
-                  <input type="submit" value="북마크 취소">
-                {% else %}
-                  <input type="submit" value="북마크">
-                {% endif %}
-              </form>
+              <div class="recommend-grid">
+                <span class="recommend-label">상품 이름</span>
+                <span class="recommend-value">{{ msg.product.fin_prdt_nm}}</span>
+
+                <span class="recommend-label">은행</span>
+                <span class="recommend-value">{{ msg.product.kor_co_nm }}</span>
+
+                <span class="recommend-label">설명</span>
+                <span class="recommend-value">{{ msg.product.description }}</span>
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
### 작업 개요
채팅 페이지 내 북마크 기능 UI 개선

### 변경 사항
- 금융 상품 추천 카드 UI 개선
- `products/search/` 페이지와 관심 상품 등록 버튼 디자인 통일

### 확인 요청
<img width="1901" height="947" alt="image" src="https://github.com/user-attachments/assets/b0e8bd82-f11e-421f-8264-a27d61b6dbd7" />

- [x] '예금 추천' 등 '추천' 단어가 들어간 메세지 입력 시 추천 카드 출력 확인 (사진 참고)
- [x] 북마크 추가/삭제 버튼 UI 개선
  - [x] 북마크 등록된 경우: 노란색 채워진 별 아이콘
  - [x] 북마크 등록되지 않은 경우: 회색 비어 있는 별 아이콘
  - [x] 아이콘이 서로 반대로 동작하고 있지는 않은지 확인 부탁 드립니다. 
  - [x] 북마크 추가 후 관심 상품 페이지 `http://127.0.0.1:8000/accounts/bookmark/`에 추가되었는지 확인 