### PR TITLE
[FIX] 챗봇이 한번 상품 추천을 하고 난 뒤에 계속해서 상품 추천 정보가 출력되는 현상 수정

### DIFF
--- a/chatbot/views.py
+++ b/chatbot/views.py
@@ -115,10 +115,10 @@ def chat_page(request, chatroom_pk=None):
             request.session["need_user_feedback"] = reply["need_user_feedback"]
             ChatMessage.objects.create(user=request.user, room=chat_room, role="bot", message=answer)
 
-            # 챗봇의 응답을 바탕으로 추천받은 금융 상품이 있다면 해당 상품을 외래키로 가지는 채팅을 하나 추가합니다.
-            if chat.state.get("product_code"):
+            # 사용자의 채팅을 바탕으로 현재 챗봇이 recommend mode라면 추천 상품 정보를 채팅에 추가합니다.
+            if reply["recommend_mode"]:
                 # 추천받은 상품
-                product = FinProduct.objects.get(fin_prdt_cd=chat.state["product_code"])
+                product = FinProduct.objects.get(fin_prdt_cd=reply["product_code"])
                 ChatMessage.objects.create(
                     user=request.user, room=chat_room, role="bot", message="추천상품", product=product
                 )

--- a/rag_flow/graph_nodes.py
+++ b/rag_flow/graph_nodes.py
@@ -413,7 +413,6 @@ def rag_search(state: ChatState) -> ChatState:
     answer = completion.choices[0].message.content
     recommend_mode = True
     # 추천받은 상품을 view로 연결
-    print(vector_db_answer)
     product_code = vector_db_answer["금융상품코드"]
     return {
         "answer": answer,


### PR DESCRIPTION
### 작업 개요
챗봇에게 상품 추천을 받고난 후 해당 상품의 정보가 추천과는 무관한 채팅의 답변과 함께 계속해서 출력되던 현상을 수정하였습니다.

### 변경 사항
- 추천 상품 정보가 출력되는 명확한 조건을 설정하였습니다.

### 확인 요청
- [x] 챗봇에게 상품 추천 요청 후 이후 아무 채팅을 입력하였을 때, 받았던 추천 상품 정보가 중복으로 출력되지 않으면 정상입니다.
