### PR TITLE
[FEAT] 상품 상세 페이지 구현

### DIFF
--- a/products/templates/products/product_detail.html
+++ b/products/templates/products/product_detail.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+
+{% block content %}
+  <h1>상품명: {{ product.fin_prdt_nm }}</h1>
+  {% comment %} <p>{{ product.fin_prdt_cd }}</p> 기본 식별자(PK) {% endcomment %}
+  <p>금융회사명: {{ product.kor_co_nm }}</p>
+  {% comment %} <p>{{ product.fin_co_no }}  # 금융회사 정보</p> {% endcomment %}
+  
+
+  <p>가입방법: {{ product.join_way }}</p>
+
+  <p>회사유형: {{ product.company_type }}</p>
+  {% comment %} <p>카테고리: {{ product.category }}</p> {% endcomment %}
+
+  <p>공시 시작일: {{ product.dcls_strt_day }}</p>
+  <p>공시 종료일: {{ product.dcls_end_day }}</p>
+  <p>공시 월: {{ product.dcls_month }}</p>
+
+  <p>상품 설명: {{ product.description }}</p>
+
+  {% if product.category == "installment_deposit" %}
+  {% comment %} 적금 {% endcomment %}
+    <h3>적금 옵션</h3>
+    {% for p in product.installment_options.all %}
+      <p>가입 대상: {{ p.join_member }}</p>
+      <p>만기 후 이자율: {{ p.mtrt_int }}</p>
+      <p>우대조건: {{ p.spcl_cnd }}</p>
+      <p>가입제한: {{ p.join_deny }}</p>
+      <p>최고한도: {{ p.max_limit }}</p>
+      <p>적립 유형명: {{ p.rsrv_type_nm }}</p>
+      <p>저축 금리 유형명: {{ p.intr_rate_type_nm }}</p>
+      <p>저축 기간(단위: 개월){{ p.save_trm }}</p>
+      <p>저축 금리: {{ p.intr_rate }}</p>
+      <p>최고 우대 금리: {{ p.intr_rate2 }}</p>
+      <p>공시 제출월: {{ p.dcls_month }}</p>
+      <hr>
+    {% endfor %}
+
+
+  {% elif product.category == "fixed_deposit" %}
+  {% comment %} 정기 예금 {% endcomment %}
+    <h3>정기 예금 옵션</h3>
+    {% for p in product.fixed_options.all %}
+      <p>가입 대상: {{ p.join_member }}</p>
+      <p>만기 후 이자율: {{ p.mtrt_int }}</p>
+      <p>우대조건: {{ p.spcl_cnd }}</p>
+      <p>가입제한: {{ p.join_deny }}</p>
+      <p>최고한도: {{ p.max_limit }}</p>
+      <p>저축 금리 유형명: {{ p.intr_rate_type_nm }}</p>
+      <p>저축 기간(단위: 개월){{ p.save_trm }}</p>
+      <p>저축 금리: {{ p.intr_rate }}</p>
+      <p>최고 우대 금리: {{ p.intr_rate2 }}</p>
+      <p>공시 제출월: {{ p.dcls_month }}</p>
+      <hr>
+    {% endfor %}
+
+  {% elif product.category == "jeonse_loan" %}
+  {% comment %} 전세 대출 {% endcomment %}
+    <h3>전세 대출 옵션</h3>
+    {% for p in product.jeonse_options.all %}
+      <p>대출 부대비용: {{ p.loan_inci_expn }}</p>
+      <p>중도상환 수수료: {{ p.erly_rpay_fee }}</p>
+      <p>연체 이자율: {{ p.dly_rate }}</p>
+      <p>대출한도: {{ p.loan_lmt }}</p>
+      <p>대출상환유형코드: {{ p.rpay_type_nm }}</p>
+      <p>대출금리유형: {{ p.lend_rate_type_nm }}</p>
+      <p>대출최저금리: {{ p.lend_rate_min }}</p>
+      <p>대출최고금리: {{ p.lend_rate_max }}</p>
+      <p>전월 취급 평균 금리: {{ p.lend_rate_avg }}</p>
+      <p>공시 제출월: {{ p.dcls_month }}</p>
+      <hr>
+    {% endfor %}
+  {% endif %}
+
+{% endblock content %}

--- a/products/templates/products/product_detail.html
+++ b/products/templates/products/product_detail.html
@@ -1,75 +1,75 @@
 {% extends "base.html" %}
 
+
 {% block content %}
-  <h1>상품명: {{ product.fin_prdt_nm }}</h1>
-  {% comment %} <p>{{ product.fin_prdt_cd }}</p> 기본 식별자(PK) {% endcomment %}
-  <p>금융회사명: {{ product.kor_co_nm }}</p>
-  {% comment %} <p>{{ product.fin_co_no }}  # 금융회사 정보</p> {% endcomment %}
-  
+  <div class="container">
+    <h1>상품명: {{ product.fin_prdt_nm }}</h1>
+    {% comment %} <p>{{ product.fin_prdt_cd }}</p> 기본 식별자(PK) {% endcomment %}
+    {% comment %} <p>{{ product.fin_co_no }}  # 금융회사 정보</p> {% endcomment %}
+    {% comment %} <p>카테고리: {{ product.category }}</p> {% endcomment %}
 
-  <p>가입방법: {{ product.join_way }}</p>
+    <p>금융회사명: {{ product.kor_co_nm }}</p>
 
-  <p>회사유형: {{ product.company_type }}</p>
-  {% comment %} <p>카테고리: {{ product.category }}</p> {% endcomment %}
+    <p class="item">가입방법: {{ product.join_way }}</p>
+    <p class="item">회사유형: {{ product.company_type }}</p>
 
-  <p>공시 시작일: {{ product.dcls_strt_day }}</p>
-  <p>공시 종료일: {{ product.dcls_end_day }}</p>
-  <p>공시 월: {{ product.dcls_month }}</p>
+    <p class="item">공시 시작일: {{ product.dcls_strt_day }}</p>
+    <p class="item">공시 종료일: {{ product.dcls_end_day }}</p>
+    <p class="item">공시 월: {{ product.dcls_month }}</p>
+    <p class="item">상품 설명: {{ product.description }}</p>
 
-  <p>상품 설명: {{ product.description }}</p>
-
-  {% if product.category == "installment_deposit" %}
-  {% comment %} 적금 {% endcomment %}
-    <h3>적금 옵션</h3>
-    {% for p in product.installment_options.all %}
-      <p>가입 대상: {{ p.join_member }}</p>
-      <p>만기 후 이자율: {{ p.mtrt_int }}</p>
-      <p>우대조건: {{ p.spcl_cnd }}</p>
-      <p>가입제한: {{ p.join_deny }}</p>
-      <p>최고한도: {{ p.max_limit }}</p>
-      <p>적립 유형명: {{ p.rsrv_type_nm }}</p>
-      <p>저축 금리 유형명: {{ p.intr_rate_type_nm }}</p>
-      <p>저축 기간(단위: 개월){{ p.save_trm }}</p>
-      <p>저축 금리: {{ p.intr_rate }}</p>
-      <p>최고 우대 금리: {{ p.intr_rate2 }}</p>
-      <p>공시 제출월: {{ p.dcls_month }}</p>
-      <hr>
-    {% endfor %}
+    {% if product.category == "installment_deposit" %}
+    {% comment %} 적금 {% endcomment %}
+      <h3>적금 옵션</h3>
+      {% for p in installment_options %}
+        <p class="item">가입 대상: {{ p.join_member }}</p>
+        <p class="item">만기 후 이자율: {{ p.mtrt_int }}</p>
+        <p class="item">우대조건: {{ p.spcl_cnd }}</p>
+        <p class="item">가입제한: {{ p.join_deny }}</p>
+        <p class="item">최고한도: {{ p.max_limit }}</p>
+        <p class="item">적립 유형명: {{ p.rsrv_type_nm }}</p>
+        <p class="item">저축 금리 유형명: {{ p.intr_rate_type_nm }}</p>
+        <p class="item">저축 기간(단위: 개월){{ p.save_trm }}</p>
+        <p class="item">저축 금리: {{ p.intr_rate }}</p>
+        <p class="item">최고 우대 금리: {{ p.intr_rate2 }}</p>
+        <p class="item">공시 제출월: {{ p.dcls_month }}</p>
+        <hr>
+      {% endfor %}
 
 
-  {% elif product.category == "fixed_deposit" %}
-  {% comment %} 정기 예금 {% endcomment %}
-    <h3>정기 예금 옵션</h3>
-    {% for p in product.fixed_options.all %}
-      <p>가입 대상: {{ p.join_member }}</p>
-      <p>만기 후 이자율: {{ p.mtrt_int }}</p>
-      <p>우대조건: {{ p.spcl_cnd }}</p>
-      <p>가입제한: {{ p.join_deny }}</p>
-      <p>최고한도: {{ p.max_limit }}</p>
-      <p>저축 금리 유형명: {{ p.intr_rate_type_nm }}</p>
-      <p>저축 기간(단위: 개월){{ p.save_trm }}</p>
-      <p>저축 금리: {{ p.intr_rate }}</p>
-      <p>최고 우대 금리: {{ p.intr_rate2 }}</p>
-      <p>공시 제출월: {{ p.dcls_month }}</p>
-      <hr>
-    {% endfor %}
+    {% elif product.category == "fixed_deposit" %}
+    {% comment %} 정기 예금 {% endcomment %}
+      <h3>정기 예금 옵션</h3>
+      {% for p in fixed_options %}
+        <p class="item">가입 대상: {{ p.join_member }}</p>
+        <p class="item">만기 후 이자율: {{ p.mtrt_int }}</p>
+        <p class="item">우대조건: {{ p.spcl_cnd }}</p>
+        <p class="item">가입제한: {{ p.join_deny }}</p>
+        <p class="item">최고한도: {{ p.max_limit }}</p>
+        <p class="item">저축 금리 유형명: {{ p.intr_rate_type_nm }}</p>
+        <p class="item">저축 기간(단위: 개월){{ p.save_trm }}</p>
+        <p class="item">저축 금리: {{ p.intr_rate }}</p>
+        <p class="item">최고 우대 금리: {{ p.intr_rate2 }}</p>
+        <p class="item">공시 제출월: {{ p.dcls_month }}</p>
+        <hr>
+      {% endfor %}
 
-  {% elif product.category == "jeonse_loan" %}
-  {% comment %} 전세 대출 {% endcomment %}
-    <h3>전세 대출 옵션</h3>
-    {% for p in product.jeonse_options.all %}
-      <p>대출 부대비용: {{ p.loan_inci_expn }}</p>
-      <p>중도상환 수수료: {{ p.erly_rpay_fee }}</p>
-      <p>연체 이자율: {{ p.dly_rate }}</p>
-      <p>대출한도: {{ p.loan_lmt }}</p>
-      <p>대출상환유형코드: {{ p.rpay_type_nm }}</p>
-      <p>대출금리유형: {{ p.lend_rate_type_nm }}</p>
-      <p>대출최저금리: {{ p.lend_rate_min }}</p>
-      <p>대출최고금리: {{ p.lend_rate_max }}</p>
-      <p>전월 취급 평균 금리: {{ p.lend_rate_avg }}</p>
-      <p>공시 제출월: {{ p.dcls_month }}</p>
-      <hr>
-    {% endfor %}
-  {% endif %}
-
+    {% elif product.category == "jeonse_loan" %}
+    {% comment %} 전세 대출 {% endcomment %}
+      <h3>전세 대출 옵션</h3>
+      {% for p in jeonse_options %}
+        <p class="item">대출 부대비용: {{ p.loan_inci_expn }}</p>
+        <p class="item">중도상환 수수료: {{ p.erly_rpay_fee }}</p>
+        <p class="item">연체 이자율: {{ p.dly_rate }}</p>
+        <p class="item">대출한도: {{ p.loan_lmt }}</p>
+        <p class="item">대출상환유형코드: {{ p.rpay_type_nm }}</p>
+        <p class="item">대출금리유형: {{ p.lend_rate_type_nm }}</p>
+        <p class="item">대출최저금리: {{ p.lend_rate_min }}</p>
+        <p class="item">대출최고금리: {{ p.lend_rate_max }}</p>
+        <p class="item">전월 취급 평균 금리: {{ p.lend_rate_avg }}</p>
+        <p class="item">공시 제출월: {{ p.dcls_month }}</p>
+        <hr>
+      {% endfor %}
+    {% endif %}
+  </div>
 {% endblock content %}

--- a/products/templates/products/search.html
+++ b/products/templates/products/search.html
@@ -48,7 +48,7 @@
       {% for p in page_obj %}
       <div class="result-item">
         <div class="result-bookmark">
-          <p class="product-name">{{ p.fin_prdt_nm }}</p>
+          <a href="{% url "products:product_detail" p.fin_prdt_cd %}"><p class="product-name">{{ p.fin_prdt_nm }}</p></a>
 
           <form method="POST" action="{% url 'accounts:bookmark' p.fin_prdt_cd %}">
             {% csrf_token %}
@@ -83,6 +83,7 @@
 
         <div class="label">상품 설명</div>
         <div class="value">{{ p.description }}</div>
+
       </div>
 
       </div>

--- a/products/urls.py
+++ b/products/urls.py
@@ -8,4 +8,5 @@ app_name = "products"
 urlpatterns = [
     path("", views.index, name="index"),
     path("search/", views.search, name="search"),
+    path("<str:fin_prdt_cd>/", views.product_detail, name="product_detail"),
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -109,3 +109,8 @@ def search(request):
         "show_next_10": show_next_10,
     }
     return render(request, "products/search.html", context)
+
+
+def product_detail(request, fin_prdt_cd):
+    product = FinProduct.objects.get(fin_prdt_cd=fin_prdt_cd)
+    return render(request, "products/product_detail.html", {"product": product})

--- a/products/views.py
+++ b/products/views.py
@@ -112,5 +112,67 @@ def search(request):
 
 
 def product_detail(request, fin_prdt_cd):
+    """
+    금융상품 상세 페이지 렌더링 뷰
+
+    이 뷰는 금융상품(FinProduct)의 기본 정보와 관련된 옵션 테이블
+    (정기예금 옵션, 적금 옵션, 전세자금대출 옵션)을 하나의 상세 페이지에서
+    모두 조회 및 출력하기 위한 데이터 전처리 로직을 포함
+
+    주요 처리 로직
+    ----------------
+    1. 기본 상품(FinProduct) 객체 조회
+       - fin_prdt_cd(PK)로 단일 상품 객체 조회
+       - ForeignKey 필드를 제외한 모든 단일 필드 값을 검사하여
+       None, "None", "null" 등의 값은 빈 문자열("")로 치환
+
+    2. 옵션 테이블 데이터 조회 및 전처리
+       - product.fixed_options, installment_options, jeonse_options를
+       각각 list로 치환
+       - 각 옵션의 단일 필드 값 또한 None / 문자열 None 계열 값을 공백으로 변환
+
+    3. 템플릿 전달
+       - 기본 정보: product
+       - 옵션 정보: fixed_options / installment_options / jeonse_options
+
+    Args:
+        request (HttpRequest): 클라이언트 요청 객체
+        fin_prdt_cd (str): 금융상품 기본 코드(PK)
+
+    Returns:
+        HttpResponse: 전처리된 상품 정보 및 옵션 데이터를 포함한 상세 페이지 렌더링 결과
+    """
     product = FinProduct.objects.get(fin_prdt_cd=fin_prdt_cd)
-    return render(request, "products/product_detail.html", {"product": product})
+
+    # 공통 필드 전처리
+    for field in product._meta.fields:
+        if field.is_relation:
+            continue
+
+        value = getattr(product, field.name)
+        if value in [None, "None", "none", "NULL", "null"]:
+            setattr(product, field.name, "")
+
+    # 옵션 테이블 조회
+    fixed = list(product.fixed_options.all())
+    inst = list(product.installment_options.all())
+    jeonse = list(product.jeonse_options.all())
+
+    # 옵션 테이블 전처리
+    for option_list in [fixed, inst, jeonse]:
+        for opt in option_list:
+            for f in opt._meta.fields:
+                if f.is_relation:
+                    continue
+
+                val = getattr(opt, f.name)
+                if val in [None, "None", "none", "NULL", "null"]:
+                    setattr(opt, f.name, "")
+    context = {
+        "product": product,
+        "fixed_options": fixed,
+        "installment_options": inst,
+        "jeonse_options": jeonse,
+    }
+
+    return render(request, "products/product_detail.html", context)


### PR DESCRIPTION
### 작업 개요
상품 상세 페이지 동적 렌더링

### 변경 사항
- 상품 카테고리에 따른 상품 상세 페이지 구현
- Null 값 빈 문자열 처리
- 검색 페이지 결과에서 상품 상세 페이지로 링크 연결

### 확인 요청
- [x] products/<상품 코드>/ 또는 검색 페이지에서 상품 이름 클릭 시 해당 상품 상세 페이지로 이동
- [x] 기존 None으로 뜨던 필드 빈 문자열로 출력
- [x] 상품 카테고리(대출, 적금, 예금)에 따른 출력 필드 변화

### 참고 사항
- 관련 이슈: #267 
- Null값은 제가 임으로 빈 문자열로 아무것도 출력 안되게 했습니다. 대체 텍스트에 대한 아이디어가 있다면 알려주세용
- 상세 페이지에 출력되는 필드도 임의로 했습니다. 제안사항 있으시면 알려주세용