### PR TITLE
[REFACTOR] 화면 전반 레이아웃 및 UI/UX 구조 개선

### DIFF
--- a/accounts/static/accounts/css/bookmark-list.css
+++ b/accounts/static/accounts/css/bookmark-list.css
@@ -24,12 +24,18 @@ body {
     align-items: center;
     position: relative;
     padding-top: 30px;
+    row-gap: 15px;
 }
 
-.left-group,
+.left-group {
+    display: flex;
+}
+
 .right-group {
     display: flex;
+    flex-wrap: wrap;
     gap: 35px;
+    padding-left: 10px;
 }
 
 .header a {

--- a/accounts/static/accounts/css/bookmark-list.css
+++ b/accounts/static/accounts/css/bookmark-list.css
@@ -77,9 +77,11 @@ body {
 }
 
 .product-container {
+    width: 100%;
+    min-width: 360px;
     display: grid;
     justify-content: space-around;
-    grid-template-columns: repeat(auto-fill, minmax(450px, 450px));
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
     gap: 30px;
 }
 
@@ -188,5 +190,11 @@ body {
     .chatbot-btn img {
         content: url('/static/images/finbot-btn-short.png');
         width: 55px;
+    }
+}
+
+@media (max-height: 500px) {
+    .chatbot-btn {
+        display: none;
     }
 }

--- a/accounts/static/accounts/css/mypage-layout.css
+++ b/accounts/static/accounts/css/mypage-layout.css
@@ -1,79 +1,84 @@
 /* mypage-layout.css */
 /* 회원 정보 관련 페이지에서 사용되는 공통 템플릿 */
-
 /* 1. update.html (회원 정보 조회 및 수정 페이지) */
 /* 2. password.html (비밀번호 변경 페이지) */
 
 /* 배경 */
 html, body {
-  height: 100%;
-  margin: 0;
-  background-color: #FFFFFF;
-  font-family: 'Pretendard', sans-serif;
+    height: 100%;
 }
 
-/* 컨테이너 */
+body {
+    margin: 0;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #F3F3F3;
+    font-family: 'Pretendard', sans-serif;
+}
+
+/* 입력 폼 컨테이너 */
 .container {
-  height: 100%;
-  display: flex;
-  gap: 40px;
-  padding: 20px;
-  box-sizing: border-box;
+    width: 80%;
+    min-width: 450px;
+    max-width: 1000px;
+    height: 80vh;
+    max-height: 650px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    border-radius: 20px;
+    background-color: #FFFFFF;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.05);
 }
 
-/* ---------- */
-/* 1. 사이드바 */
-/* ---------- */
-.sidebar {
-  width: 270px;
-  height: 100%;
-  background-color: #F3F3F3;
-  color: #8B8B8B; 
-  padding: 50px 0px 30px 40px;
-  box-sizing: border-box;
-  display: flex;
-  gap: 25px;
-  flex-shrink: 0;  /* 최소 너비 보장*/
-  flex-direction: column;
-  border-radius: 15px;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
-}
-
-/* 로고 */
+/* -------- */
+/* 1. 상단바 */
+/* -------- */
 .main-link img {
   height: 25px;
-  width: auto;
-  display: block;
-  padding-bottom: 20px;
+  padding-left: 10px;
 }
 
-/* 내부 글씨 */
-.sidebar a {
-  text-decoration: none;
-  font-size: 16px;
-  color: #8B8B8B;
+.header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 20px;
+    padding: 50px 60px 40px 50px;
 }
 
-.sidebar a.active {
+.left-group {
+    display: flex;
+}
+
+.right-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 35px;
+    padding-left: 10px;
+}
+
+.right-group .active {
   color: #3F72AF;
-  font-weight: 700;
 }
 
-/* 로그아웃 */
-.logout-link {
-  margin-top: auto;
+.header a {
+    text-decoration: none;
+    border: none;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 40px;
+    font-size: 15px;
+    font-weight: 700;
+    color: #8B8B8B;
 }
 
 /* --------------- */
 /* 2. 폼 공통 스타일 */
 /* --------------- */
-form {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex-grow: 1;
-}
-
 form input:focus {
   outline: none; 
   border-color: #8B8B8B;

--- a/accounts/static/accounts/css/password.css
+++ b/accounts/static/accounts/css/password.css
@@ -2,18 +2,14 @@
 /* 비밀번호 변경 페이지 개별 템플릿 */
 
 form {
-  justify-content: center;
+  display: flex;
+  flex-direction: column;
   gap: 25px;
+  margin: 60px;
 }
 
-input {
-  width: 400px;
+input, button {
+  width: 50%;
   height: 50px;
   font-size: 15px;
-}
-
-/* 저장 버튼 */
-button {
-  width: 400px;
-  height: 50px;
 }

--- a/accounts/static/accounts/css/password.css
+++ b/accounts/static/accounts/css/password.css
@@ -5,11 +5,22 @@ form {
   display: flex;
   flex-direction: column;
   gap: 25px;
-  margin: 60px;
+  margin: 60px auto;
 }
 
 input, button {
-  width: 50%;
+  width: 400px;
   height: 50px;
   font-size: 15px;
+}
+
+@media (max-width: 716px) {
+  form {
+    margin: 0;
+  }
+
+  input, button {
+    width: calc(100% - 120px);
+    margin: 0 60px;
+  }
 }

--- a/accounts/static/accounts/css/update.css
+++ b/accounts/static/accounts/css/update.css
@@ -53,7 +53,6 @@ select {
     display: flex;
     justify-content: flex-end;
     gap: 15px;
-    padding-right: 60px;
 }
 
 /* 정보 수정 버튼 */

--- a/accounts/static/accounts/css/update.css
+++ b/accounts/static/accounts/css/update.css
@@ -1,64 +1,90 @@
 /* update.css */
-/* 회원 정보 조회 및 수정 페이지 개별 템플릿 */
+/* 회원 정보 조회 및 수정 페이지 템플릿 */
 
 form {
-  margin-top: 50px;
-  position: relative;
-  gap: 30px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 30px;
+    margin: 30px 0;
+    padding: 0 60px;
+    box-sizing: border-box;
 }
 
 .form-row {
-  display: flex;
-  justify-content: space-between;
-  gap: 200px;
+    display: flex;
+    gap: 60px;
+    width: 100%;
+    justify-content: space-evenly;
 }
 
 .form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  width: 400px;
-}
-
-/* 항목의 이름 */
-label {
-  font-size: 15px;
-  font-weight: 700;
-  color: #8B8B8B;
+    flex: 1 1 0; 
+    max-width: 435px;
+    min-width: 280px; 
+    display: flex;
+    flex-direction: column;
 }
 
 input, select {
-  width: 450px;
-  height: 50px;
+    width: 100%;
+    height: 50px;
+    box-sizing: border-box;
 }
 
-select:focus {
-  outline: none; 
-  border-color: #8B8B8B;
+label {
+    font-size: 15px;
+    font-weight: 700;
+    color: #8B8B8B;
+    margin-bottom: 10px;
 }
 
 /* 선택 폼 기본 화살표 제거 */
 select {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  background: #FFFFFF url("data:image/svg+xml,%3Csvg fill='%238B8B8B' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E") no-repeat right 20px center;
-  background-size: 20px;
-  padding-right: 30px;
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: #FFFFFF url("data:image/svg+xml,%3Csvg fill='%238B8B8B' height='24' viewBox='0 0 24 24' width='24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M7 10l5 5 5-5z'/%3E%3C/svg%3E") no-repeat right 20px center;
+    background-size: 20px;
+    padding-right: 30px;
 }
 
-/* 하단 버튼 그룹 */
 .btn-group {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 40px;
-  gap: 15px;
-  width: 1100px;
-  justify-content: flex-end;
+    display: flex;
+    justify-content: flex-end;
+    gap: 15px;
+    padding-right: 60px;
 }
 
 /* 정보 수정 버튼 */
 .btn-bottom-right {
-  width: 135px;
-  height: 55px;
+    width: 140px;
+    height: 53px;
+}
+
+/* 반응형 */
+@media (max-width: 900px) {
+  .header {
+        padding: 50px 60px 0 50px;
+    }
+
+    form {
+        padding: 0 60px;
+    }
+
+    .form-row {
+        flex-direction: column;
+        gap: 30px;
+    }
+
+    .form-group {
+        flex: 1 1 100%;
+        max-width: 100%;
+        min-width: unset;
+    }
+
+    .btn-group {
+        justify-content: center;
+        padding: 0 0 30px 0;
+    }
 }

--- a/accounts/templates/accounts/password.html
+++ b/accounts/templates/accounts/password.html
@@ -61,7 +61,7 @@
     >
 
     {# 4. 변경 내역 저장 버튼 #}
-    <button type="submit" class="btn-group">비밀번호 변경</button>
+    <button type="submit">비밀번호 변경</button>
   </form>
 </div>
 

--- a/accounts/templates/accounts/password.html
+++ b/accounts/templates/accounts/password.html
@@ -12,22 +12,20 @@
 {% block content %}
 <div class="container">
 
-  {# 사이드바 #}
-  <div id="sidebar" class="sidebar">
+  {# 상단바 #}
+  <header class="header">
+    <div class="left-group">
+      <a href="{% url 'products:index' %}" class="main-link">
+        <img src="{% static 'images/logo-white.png' %}" alt="FINBOT Logo">
+      </a>
+    </div>
 
-    {# 로고 이미지 #}
-    <a href="{% url 'products:index' %}" class="main-link">
-      <img src="{% static 'images/logo-gray.png' %}" alt="FINBOT Logo">
-    </a>
-
-    {# 페이지 항목 #}
-    <a href="{% url 'accounts:update' %}">회원정보 수정</a>
-    <a href="{% url 'accounts:password' %}" class="active">비밀번호 변경</a>
-    <a href="{% url 'accounts:delete' %}">회원 탈퇴</a>
-
-    {# 로그아웃 버튼 #}
-    <a href="{% url 'accounts:logout' %}" class="logout-link">로그아웃</a>
-  </div>
+    <div class="right-group">
+        <a href="{% url 'accounts:update' %}">회원정보 수정</a>
+        <a href="{% url 'accounts:password' %}" class="active">비밀번호 변경</a>
+        <a href="{% url 'accounts:delete' %}">회원 탈퇴</a>
+    </div>
+  </header>
 
   <form action="{% url "accounts:password" %}" method="POST">
     {% csrf_token %}
@@ -63,7 +61,7 @@
     >
 
     {# 4. 변경 내역 저장 버튼 #}
-    <button type="submit">비밀번호 변경</button>
+    <button type="submit" class="btn-group">비밀번호 변경</button>
   </form>
 </div>
 

--- a/accounts/templates/accounts/update.html
+++ b/accounts/templates/accounts/update.html
@@ -12,6 +12,7 @@
 {% block content %}
 <div class="container">
 
+  {# 상단바 #}
   <header class="header">
     <div class="left-group">
       <a href="{% url 'products:index' %}" class="main-link">
@@ -70,15 +71,15 @@
         {{ form.life_area }}
       </div>
     </div>
-  </form>
 
-  {# 7. 채팅/정보 수정 내역 저장 버튼 #}
-  <div class="btn-group">
-    <a href="{% url 'chat:current_chat' %}" class="chatbot-btn">
-      <img src="{% static 'images/finbot-btn-long.png' %}" alt="FINBOT Chat">
-    </a>
-    <button type="submit" class="btn-bottom-right">정보 수정</button>
-  </div>
+    {# 7. 채팅/정보 수정 내역 저장 버튼 #}
+    <div class="btn-group">
+      <a href="{% url 'chat:current_chat' %}" class="chatbot-btn">
+        <img src="{% static 'images/finbot-btn-long.png' %}" alt="FINBOT Chat">
+      </a>
+      <button type="submit" class="btn-bottom-right">정보 수정</button>
+    </div>
+  </form>
 </div>
 
 <script>

--- a/accounts/templates/accounts/update.html
+++ b/accounts/templates/accounts/update.html
@@ -11,23 +11,20 @@
 
 {% block content %}
 <div class="container">
-  
-  {# 사이드바 #}
-  <div id="sidebar" class="sidebar">
 
-    {# 로고 이미지 #}
-    <a href="{% url 'products:index' %}" class="main-link">
-      <img src="{% static 'images/logo-gray.png' %}" alt="FINBOT Logo">
-    </a>
+  <header class="header">
+    <div class="left-group">
+      <a href="{% url 'products:index' %}" class="main-link">
+        <img src="{% static 'images/logo-white.png' %}" alt="FINBOT Logo">
+      </a>
+    </div>
 
-    {# 페이지 항목 #}
-    <a href="{% url 'accounts:update' %}" class="active">회원정보 수정</a>
-    <a href="{% url 'accounts:password' %}">비밀번호 변경</a>
-    <a href="{% url 'accounts:delete' %}">회원 탈퇴</a>
-
-    {# 로그아웃 버튼 #}
-    <a href="{% url 'accounts:logout' %}" class="logout-link">로그아웃</a>
-  </div>
+    <div class="right-group">
+        <a href="{% url 'accounts:update' %}" class="active">회원정보 수정</a>
+        <a href="{% url 'accounts:password' %}">비밀번호 변경</a>
+        <a href="{% url 'accounts:delete' %}">회원 탈퇴</a>
+    </div>
+  </header>
 
   <form action="{% url 'accounts:update' %}" method="POST">
     {% csrf_token %}
@@ -73,15 +70,15 @@
         {{ form.life_area }}
       </div>
     </div>
-
-    {# 7. 채팅/정보 수정 내역 저장 버튼 #}
-    <div class="btn-group">
-      <a href="{% url 'chat:current_chat' %}" class="chatbot-btn">
-        <img src="{% static 'images/finbot-btn-long.png' %}" alt="FINBOT Chat">
-      </a>
-      <button type="submit" class="btn-bottom-right">정보 수정</button>
-    </div>
   </form>
+
+  {# 7. 채팅/정보 수정 내역 저장 버튼 #}
+  <div class="btn-group">
+    <a href="{% url 'chat:current_chat' %}" class="chatbot-btn">
+      <img src="{% static 'images/finbot-btn-long.png' %}" alt="FINBOT Chat">
+    </a>
+    <button type="submit" class="btn-bottom-right">정보 수정</button>
+  </div>
 </div>
 
 <script>

--- a/products/static/products/css/index.css
+++ b/products/static/products/css/index.css
@@ -3,7 +3,6 @@ body {
     padding: 0;
     background-color: #FFFFFF;
     font-family: 'Pretendard', sans-serif;
-    height: 100vh;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -63,16 +62,22 @@ body {
 }
 
 .main-content {
-    margin-top: 20vh; 
+    width: 100%;
+    max-width: 1200px;
+    margin: 200px auto 0 auto;
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 0 20px; 
+    box-sizing: border-box;
 }
 
 .search-form {
     display: flex;
     justify-content: center;
-    width: 1000px;
+    width: 100%;
+    max-width: 1000px;
+    min-width: 400px;
 }
 
 .search-input-wrapper {
@@ -136,7 +141,6 @@ body {
     margin-top: 70px;
     width: 100%;
     max-width: 1200px;
-    text-align: left;
 }
 
 .recommend-title {
@@ -144,7 +148,6 @@ body {
     font-weight: 800;
     margin-bottom: 25px;
     color: #5a5a5a;
-    padding-left: 5px;
 }
 
 .highlight-title {
@@ -153,22 +156,25 @@ body {
 }
 
 .card-container {
-    display: flex;
-    gap: 50px;
-    justify-content: center;
+    width: 100%;
+    min-width: 300px;
+    display: grid;
+    justify-items: center;
+    padding: 0 20px;
+    box-sizing: border-box;
+    grid-gap: 70px;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 }
 
 .rec-card {
-    width: 300px;
-    height: 200px;
+    width: 100%;
+    min-height: 200px;
     padding: 25px;
     background-color: #F3F3F3;
     border-radius: 20px;
     box-shadow: 0 4px 12px rgba(0,0,0,0.05);
     transition: transform 0.2s, box-shadow 0.2s;
     display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
 }
 
 .rec-card h3 {
@@ -203,17 +209,16 @@ body {
 /* ------------- */
 
 .pagination {
-    display: flex;
-    justify-content: right;
-    padding-top: 20px;
     font-size: 13px;
+    padding: 30px 0;
+    display: flex;
+    justify-content: center;
 }
 
 .pagination a {
     color: #8B8B8B;
     text-decoration: none;
     padding: 5px 10px;
-    border-radius: 8px;
 }
 
 .pagination span {

--- a/products/static/products/css/index.css
+++ b/products/static/products/css/index.css
@@ -239,3 +239,9 @@ body {
     display: block;
     z-index: 1000;
 }
+
+@media (max-height: 500px) {
+    .chatbot-btn {
+        display: none;
+    }
+}

--- a/products/static/products/css/search.css
+++ b/products/static/products/css/search.css
@@ -13,23 +13,31 @@ body {
 /* -------- */
 
 .main-link img {
-  height: 23px;
+  height: 25px;
   padding-left: 10px;
 }
 
 .header {
     box-sizing: border-box;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     align-items: center;
     position: relative;
-    padding: 30px 0px 15px;
+    padding-top: 30px;
+    /* flex-wrap 상태에 간격 부여 */
+    row-gap: 15px;
 }
 
-.left-group,
+.left-group {
+    display: flex;
+}
+
 .right-group {
     display: flex;
+    flex-wrap: wrap;
     gap: 35px;
+    padding-left: 10px;
 }
 
 .header a {
@@ -60,6 +68,7 @@ body {
 
 .search-header {
   width: 100%;
+  margin-top: 40px;
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -133,17 +142,23 @@ body {
 }
 
 .product-name {
-    font-size: 17px;
+    font-size: 18px;
     font-weight: 700;
     color: #000000;
 }
+
+/* 링크 밑줄 제거 */
+.product-name-link {
+    text-decoration: none;
+}
+
 
 .info-grid {
     display: grid;
     grid-template-columns: 150px 1fr;
     row-gap: 15px;
     margin-top: 10px;
-    font-size: 15px;
+    font-size: 16px;
 }
 
 .label {
@@ -157,7 +172,7 @@ body {
 }
 
 .no-result {
-    font-size: 15px;
+    font-size: 16px;
     color: #000000;
     padding: 50px;
 }
@@ -239,5 +254,11 @@ body {
     .chatbot-btn img {
         content: url('/static/images/finbot-btn-short.png');
         width: 55px;
+    }
+}
+
+@media (max-height: 500px) {
+    .chatbot-btn {
+        display: none;
     }
 }

--- a/products/templates/products/search.html
+++ b/products/templates/products/search.html
@@ -48,7 +48,7 @@
       {% for p in page_obj %}
       <div class="result-item">
         <div class="result-bookmark">
-          <a href="{% url "products:product_detail" p.fin_prdt_cd %}"><p class="product-name">{{ p.fin_prdt_nm }}</p></a>
+          <a href="{% url "products:product_detail" p.fin_prdt_cd %}" class="product-name-link"><p class="product-name">{{ p.fin_prdt_nm }}</p></a>
 
           <form method="POST" action="{% url 'accounts:bookmark' p.fin_prdt_cd %}">
             {% csrf_token %}


### PR DESCRIPTION
### 작업 개요
화면 전반 레이아웃 및 UI/UX 구조 개선

### 변경 사항
- 메인 페이지 반응형 구조 개선
- 회원 정보 페이지 레이아웃 및 반응형 구조 재정비
- 비밀번호 변경 페이지 레이아웃 및 반응형 구조 재정비

### 확인 요청

`http://127.0.0.1:8000/`

- [x] 메인 페이지 화면 크기에 따른 레이아웃 변동 적용 여부 확인
  - 관심 상품이 세 개 이상일 때의 전체 화면 → 가로 폭 축소 → 모바일 환경

<img width="1916" height="913" alt="image" src="https://github.com/user-attachments/assets/de85fc2f-d28f-4a15-bb18-08840d9adb61" />

<img width="937" height="778" alt="image" src="https://github.com/user-attachments/assets/509bc873-0daa-4611-a6ba-da4607a49f52" />

<img width="550" height="778" alt="image" src="https://github.com/user-attachments/assets/3e3b5566-67e4-4f31-acf4-eb2edd469c77" />

<br>

`http://127.0.0.1:8000/update/`

- [x] 회원 정보 수정 페이지 화면 크기에 따른 레이아웃 변동 적용 여부 확인
  - 전체 화면 → 가로 폭 축소 → 모바일 환경 (모바일 환경에서는 버튼 그룹은 화면 중앙에 위치)
- [x] 회원 정보 수정 후 `정보 수정` 버튼 클릭 시 반영 여부
  - 다른 페이지로 이동 후 변경한 정보 반영 여부 확인

<img width="1909" height="911" alt="image" src="https://github.com/user-attachments/assets/beeb093d-abe7-4466-9865-2321a9934d47" />

<img width="1124" height="778" alt="image" src="https://github.com/user-attachments/assets/610a50bb-2ebf-417f-8976-703d24eeba7b" />

<img width="619" height="771" alt="image" src="https://github.com/user-attachments/assets/da2f10c6-f70c-452c-94cc-769e1faf8124" />
<img width="618" height="774" alt="image" src="https://github.com/user-attachments/assets/dd34ef47-9e6e-4a45-b8db-2dd7c9c8f9ce" />

<br>
 
`http://127.0.0.1:8000/password`

<img width="1915" height="909" alt="image" src="https://github.com/user-attachments/assets/76e6e971-a57b-436b-ad18-46887d73a8b0" />

<img width="530" height="777" alt="image" src="https://github.com/user-attachments/assets/b3dfb5bb-9d9b-458a-bdf0-2fb0de9f153f" />


- [x] 비밀번호 변경 페이지 화면 크기에 따른 레이아웃 변동 적용 여부 확인
  - 전체 화면 → 모바일 환경
- [x] 비밀번호 변경 후 `비밀번호 변경` 버튼 클릭 시 반영 여부
  - 회원 정보 페이지 진입 시 인증 재시도 또는 로그아웃 후 재로그인을 통한 확인

### 참고 사항
- 관련 이슈: #280
- 테스트 방법: `python manage.py runserver`