### PR TITLE
[FIX] 메인 페이지 상품 추천 로직 수정 - 로그인/비로그인 조건 정교화 및 출력 오류 수정

### DIFF
--- a/products/templates/products/index.html
+++ b/products/templates/products/index.html
@@ -36,11 +36,13 @@
     <button type="submit" style="display: none;">검색</button>
   </form>
 
+
+  {# 추천 섹션 (비로그인 + 북마크 0) #}
   {% if recommended_products %}
   <section class="recommend-section">
     <h2 class="recommend-title">
       {% if request.user.is_authenticated %}
-        {{ request.user.display_name }}님께 추천하는
+        {{ request.user.display_name }}님께 추천드리는
         <span class="highlight-title">금융상품</span>
       {% else %}
         고객님께 추천드리는
@@ -52,12 +54,71 @@
       {% for p in recommended_products %}
         <div class="rec-card">
           <div class="rec-card-inner">
+
             <h3>{{ p.fin_prdt_nm }}</h3>
+
             <p>{{ p.kor_co_nm }}</p>
+
+            <p>{{ p.description }}</p>
+
           </div>
         </div>
       {% endfor %}
     </div>
+  </section>
+  {% endif %}
+
+  {# 관심상품 헤더 (로그인 + 북마크 ≥1) #}
+  {% if request.user.is_authenticated and page_obj.paginator.count > 0 %}
+  <section class="recommend-section">
+
+      <h2 class="recommend-title">
+        {{ request.user.display_name }}님의
+        <span class="highlight-title">관심상품</span>
+      </h2>
+
+
+    {# 관심상품 #}
+    <div class="card-container">
+      {% for p in page_obj %}
+      <div class="rec-card">
+        <div class="rec-card-inner">
+
+          <h3>{{ p.fin_prdt_nm }}</h3>
+
+          <p>{{ p.kor_co_nm }}</p>
+
+          <p>{{ p.description }}</p>
+
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+
+    {# 페이지네이션 #}
+    <div class="pagination">
+      {% if page_obj.has_previous %}
+        <a href="?page={{ page_obj.previous_page_number }}">이전</a>
+      {% endif %}
+
+      <span>{{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+
+      {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}">다음</a>
+      {% endif %}
+    </div>
+
+
+
+
+
+
+
+
+
+
+
+
   </section>
   {% endif %}
 

--- a/products/views.py
+++ b/products/views.py
@@ -8,37 +8,32 @@ from django.shortcuts import render
 from accounts.models import Bookmark
 from products.models import FinProduct
 
-
 # 추천 상품 로직
 def recommend_products(request):
     """
-    홈 화면 추천 금융상품 총 3개 반환
-
     추천 로직:
-    1) 내 북마크 3개 이상: 전체 상품 중 북마크 인기순 TOP3
-    2) 내 북마크 1~2개: 내 북마크 + "내가 북마크한 카테고리 제외" 추천
-    3) 내 북마크 0개: 예금/적금/대출 각각 1개씩 추천
 
-    Args:
-        request(HttpRequest): 클라이언트의 요청 객체
-    Returns:
-        list: 추천 금융상품 3개 리스트
+    1) 비로그인 사용자 and 로그인 + 북마크 0개
+       → 적금 예금 대출 카테고리별로 랜덤 1개씩
+
+    2) 로그인 + 북마크 1개 이상
+       → 추천 섹션 없도록 빈 리스트 반환
+       index 뷰에서 처리
     """
 
-    # 내 북마크 조회
+    # 로그인 상태에서 북마크 개수 계산
+    bookmark_count = 0
     if request.user.is_authenticated:
-        bookmark_ids = Bookmark.objects.filter(user=request.user).values_list("product_id", flat=True)
-        my_bookmarks_qs = FinProduct.objects.filter(fin_prdt_cd__in=bookmark_ids)
-        my_bookmarks = list(my_bookmarks_qs)
-    else:
-        my_bookmarks_qs = FinProduct.objects.none()
-        my_bookmarks = []
+        bookmark_count = Bookmark.objects.filter(user=request.user).count()
 
-    bm_count = len(my_bookmarks)
+    # 로그인 + 북마크 1개 이상 → 추천 X
+    if request.user.is_authenticated and bookmark_count > 0:
+        return []
+
+    # 비로그인 or 북마크 0개 → 랜덤추천 3개
     selected = []
     picked_ids = set()
 
-    # 랜덤 추출 유틸
     def pick_random(qs, k):
         pool = qs.exclude(fin_prdt_cd__in=picked_ids)
         ids = list(pool.values_list("fin_prdt_cd", flat=True))
@@ -49,42 +44,14 @@ def recommend_products(request):
             picked_ids.add(p.fin_prdt_cd)
         return result
 
-    # 북마크 3개 이상 → 전체 상품 기준 인기순 TOP3
-    if bm_count >= 3:
-        return FinProduct.objects.annotate(total_bm=Count("bookmark_lists")).order_by("-total_bm")[:3]
-
-    # 북마크 1~2개 → 내 북마크 + "북마크한 카테고리 제외" 추천
-    if 1 <= bm_count <= 2:
-        selected = list(my_bookmarks)
-        picked_ids = {p.fin_prdt_cd for p in selected}
-
-        # 내가 북마크한 카테고리
-        bm_categories = my_bookmarks_qs.values_list("category", flat=True)
-
-        # 다른 카테고리에서 추천
-        others = FinProduct.objects.exclude(category__in=bm_categories)
-
-        need = 3 - len(selected)
-        selected += pick_random(others, need)
-
-        return selected[:3]
-
-    # 북마크 0개 → 예금/적금/대출 각각 1개씩
+    # 카테고리별 랜덤 추출
     deposits = FinProduct.objects.filter(category="fixed_deposit")
     savings = FinProduct.objects.filter(category="installment_deposit")
     loans = FinProduct.objects.filter(category="jeonse_loan")
 
-    selected = []
-    picked_ids = set()
-
     selected += pick_random(deposits, 1)
     selected += pick_random(savings, 1)
     selected += pick_random(loans, 1)
-
-    # 부족하면 전체에서 보충
-    if len(selected) < 3:
-        all_qs = FinProduct.objects.exclude(fin_prdt_cd__in=picked_ids)
-        selected += pick_random(all_qs, 3 - len(selected))
 
     return selected[:3]
 

--- a/products/views.py
+++ b/products/views.py
@@ -1,12 +1,13 @@
 import random
 
 from django.core.paginator import Paginator
-from django.db.models import Count, Q, Value
+from django.db.models import Q, Value
 from django.db.models.functions import Replace
 from django.shortcuts import render
 
 from accounts.models import Bookmark
 from products.models import FinProduct
+
 
 # 추천 상품 로직
 def recommend_products(request):


### PR DESCRIPTION
### 작업 개요
로그인 여부 및 북마크 보유 여부에 따른 메인 페이지 추천 섹션 노출 조건을 제가 잘못 이해하고 있었어서 기획 방향대로 수정
상품 정보(description 등) 누락 문제 해결

### 변경 사항
- 비로그인 / 로그인+북마크 0 → 카테고리별 랜덤 3개 추천
- 로그인 + 관심상품 1개 이상은 페이지네이션으로 보여주기
- 금융상품 상품 정보 표시 항목 조정

### 확인 요청
- [x] ruff format 적용 완료
- [x] 비로그인 / 로그인+북마크 0 → 카테고리별 랜덤 3개 추천
- [x] 로그인 + 관심상품 1개 이상은 페이지네이션으로 보여주기
- [x] 박스 안에 금융 상품 이름, 회사이름, 디스크립션 보이기
- [x]  PR 리뷰어가 이해할 수 있도록 템플릿/함수 내부 주석 추가

### 참고 사항
- #296  
- #292 
---
테스트 방법
#### 1) 로컬 환경 실행

1. 가상환경 활성화  

```
   source venv/Scripts/activate
```

2. 패키지 설치
```
pip install -r requirements.txt
```
3. 도커로 실행
```
docker compose up -d
docker ps
```
4. Django 마이그레이션 & 서버 실행
```
python manage.py migrate
python manage.py runserver
```
---
####  테스트
1) 북마크 0개, 로그인 안한 계정 테스트
예금/적금/대출 각 1개씩

    -> 방법
    - 메인화면 and 새 계정 생성 → 로그인하고 상품 아무것도 북마크하지 않음
    - 메인 화면 확인
    
    -> 확인 포인트
    - 추천 3개가 뜨는지
    - 카테고리가 3종류면 1개씩 나오는지


2) 북마크 1개 이상
내 북마크 목록 페이지네이션으로 보여야 함
